### PR TITLE
Usage Description Groups

### DIFF
--- a/include/usage.h
+++ b/include/usage.h
@@ -6,6 +6,7 @@ enum opt_type {
 	OPTION_INT_T,
 	OPTION_STRING_T,
 	OPTION_COMMAND_T,
+	OPTION_GROUP_T,
 	OPTION_END
 };
 
@@ -33,6 +34,7 @@ struct usage_description {
 #define OPT_INT(S,L,D)				{ (S), (L), NULL, (D), OPTION_INT_T }
 #define OPT_STRING(S,L,N,D)			{ (S), (L), (N), (D), OPTION_STRING_T }
 #define OPT_CMD(N,D)				{ 0, NULL, (N), (D), OPTION_COMMAND_T }
+#define OPT_GROUP(N)				{ 0, NULL, NULL, N, OPTION_GROUP_T }
 #define OPT_END()					{ 0, NULL, NULL, NULL, OPTION_END }
 
 #define USAGE(DESC)					{ (DESC) }

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,15 @@
+#ifndef GIT_CHAT_UTILS_H
+#define GIT_CHAT_UTILS_H
+
+#define NORETURN
+
+/**
+ * Simple assertion function. Invoking this function will cause the application
+ * to print a message to stderr, and exit with status EXIT_FAILURE.
+ *
+ * This function is primarily used to catch fail fast when an undefined state
+ * is encountered.
+ * */
+NORETURN void BUG(const char *msg, ...);
+
+#endif //GIT_CHAT_UTILS_H

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,18 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+#include "utils.h"
+
+NORETURN void BUG(const char *msg, ...)
+{
+	va_list varargs;
+	va_start(varargs, msg);
+
+	fprintf(stderr, "BUG: ");
+	vfprintf(stderr, msg, varargs);
+	fprintf(stderr, "\n");
+	va_end(varargs);
+
+	exit(EXIT_FAILURE);
+}


### PR DESCRIPTION
Added new usage_description type used as a header for usage description
groups. As always, implemented similarly to git ;) ([parse-options.h:8](https://github.com/git/git/blob/master/parse-options.h#L8)) Also added utils.c, which will be used for special ubiquitous
utilities.

In utils, I added a BUG function, which is used a bit like an assertion.
This is very similar to what is implemented in git-core ([parse-options.h:242](https://github.com/git/git/blob/master/usage.c#L242)).