### PR TITLE
Code Cleanup and Improvements

### DIFF
--- a/include/argv-array.h
+++ b/include/argv-array.h
@@ -41,6 +41,7 @@ void argv_array_release(struct argv_array *argv_a);
  *
  * This function returns the number of items pushed to the argv_array.
  * */
+__attribute__ ((sentinel))
 int argv_array_push(struct argv_array *argv_a, ...);
 
 /**
@@ -62,6 +63,7 @@ char *argv_array_pop(struct argv_array *argv_a);
  *
  * This function returns the number of items prepended to the argv_array.
  * */
+__attribute__ ((sentinel))
 int argv_array_prepend(struct argv_array *argv_a, ...);
 
 /**

--- a/include/logging.h
+++ b/include/logging.h
@@ -21,13 +21,13 @@
  * 32	NONE
  * */
 
-#define LEVEL_ALL		0
-#define LEVEL_TRACE		1 << 0
-#define LEVEL_DEBUG		1 << 1
-#define LEVEL_INFO		1 << 2
-#define LEVEL_WARN		1 << 3
-#define LEVEL_ERROR		1 << 4
-#define LEVEL_NONE		1 << 5
+#define LEVEL_ALL		(0)
+#define LEVEL_TRACE		(1 << 0)
+#define LEVEL_DEBUG		(1 << 1)
+#define LEVEL_INFO		(1 << 2)
+#define LEVEL_WARN		(1 << 3)
+#define LEVEL_ERROR		(1 << 4)
+#define LEVEL_NONE		(1 << 5)
 
 /**
  * Log a message to stdout at the trace level. Arguments to this function are

--- a/include/str-array.h
+++ b/include/str-array.h
@@ -90,6 +90,7 @@ int str_array_set_nodup(struct str_array *str_a, char *str, size_t pos);
  *
  * This function returns the number of items pushed to the str_array.
  * */
+__attribute__ ((sentinel))
 int str_array_push(struct str_array *str_a, ...);
 
 /**

--- a/include/strbuf.h
+++ b/include/strbuf.h
@@ -42,13 +42,13 @@ void strbuf_grow(struct strbuf *buff, size_t size);
  * Attach a string to the strbuf, up to buffer_len characters or until null byte
  * is encountered.
  * */
-void strbuf_attach(struct strbuf *buff, char *str, size_t buffer_len);
+void strbuf_attach(struct strbuf *buff, const char *str, size_t buffer_len);
 
 /**
  * Attach a null-terminated string to the strbuf. Similar to strbuf_attach(), except
  * uses strlen() to determine the buffer_len.
  * */
-void strbuf_attach_str(struct strbuf *buff, char *str);
+void strbuf_attach_str(struct strbuf *buff, const char *str);
 
 /**
  * Attach a single character to the strbuf.

--- a/src/argv-array.c
+++ b/src/argv-array.c
@@ -74,7 +74,7 @@ char *argv_array_collapse_delim(struct argv_array *argv_a, const char *delim)
 	}
 
 	char *str = (char *)calloc(len, sizeof(char));
-	if (str == NULL)
+	if (!str)
 		FATAL(MEM_ALLOC_FAILED);
 
 	strcat(str, str_a.strings[0]);

--- a/src/builtin/channel.c
+++ b/src/builtin/channel.c
@@ -63,7 +63,7 @@ int cmd_channel(int argc, char *argv[])
 		char *arg = argv[arg_index];
 
 		if (!is_valid_argument(arg, channel_cmd_options)) {
-			show_channel_usage(1, "error: unknown flag '%s'", arg);
+			show_channel_usage(1, "error: unknown option '%s'", arg);
 			return 1;
 		}
 
@@ -71,7 +71,7 @@ int cmd_channel(int argc, char *argv[])
 		if (arg_char_len > 1 && arg[0] != '-') {
 			//if already implicitly defined
 			if (action_mode & ACTION_MODE_CREATE) {
-				show_channel_usage(1, "error: unknown flag '%s'", arg);
+				show_channel_usage(1, "error: unknown option '%s'", arg);
 				return 1;
 			}
 

--- a/src/builtin/init.c
+++ b/src/builtin/init.c
@@ -227,6 +227,8 @@ static void update_space_description(char *base, const char *description)
 
 	close(desc_fd);
 	strbuf_release(&desc_path);
+
+	LOG_INFO("Updated space description to '%s'", description);
 }
 
 /**
@@ -304,9 +306,6 @@ int get_author_identity(struct strbuf *result)
 	struct child_process_def cmd;
 	child_process_def_init(&cmd);
 	cmd.git_cmd = 1;
-	cmd.no_in = 1;
-	cmd.no_out = 1;
-	cmd.no_err = 1;
 	argv_array_push(&cmd.args, "config", "--get", "user.username", NULL);
 	ret = capture_command(&cmd, &cmd_out);
 	child_process_def_release(&cmd);
@@ -322,9 +321,6 @@ int get_author_identity(struct strbuf *result)
 	strbuf_init(&cmd_out);
 	child_process_def_init(&cmd);
 	cmd.git_cmd = 1;
-	cmd.no_in = 1;
-	cmd.no_out = 1;
-	cmd.no_err = 1;
 	argv_array_push(&cmd.args, "config", "--get", "user.name", NULL);
 	ret = capture_command(&cmd, &cmd_out);
 	child_process_def_release(&cmd);
@@ -340,9 +336,6 @@ int get_author_identity(struct strbuf *result)
 	strbuf_init(&cmd_out);
 	child_process_def_init(&cmd);
 	cmd.git_cmd = 1;
-	cmd.no_in = 1;
-	cmd.no_out = 1;
-	cmd.no_err = 1;
 	argv_array_push(&cmd.args, "config", "--get", "user.email", NULL);
 	ret = capture_command(&cmd, &cmd_out);
 	child_process_def_release(&cmd);

--- a/src/fs-utils.c
+++ b/src/fs-utils.c
@@ -86,7 +86,7 @@ void copy_file(const char *dest, const char *src, int mode)
 			FATAL(FILE_WRITE_FAILED, dest);
 	}
 
-	if (bytes_read == -1)
+	if (bytes_read < 0)
 		FATAL("unexpected error while reading from file '%s'", src);
 
 	LOG_TRACE("File copied from '%s' to '%s'", src, dest);
@@ -189,9 +189,10 @@ char *find_in_path(const char *file)
 int is_executable(const char *name)
 {
 	struct stat st;
+	int errsv = errno;
 
 	int not_executable = stat(name, &st) || !S_ISREG(st.st_mode);
-	errno = 0;
+	errno = errsv;
 
 	return not_executable ? 0 : st.st_mode & S_IXUSR;
 }

--- a/src/git-chat.c
+++ b/src/git-chat.c
@@ -37,7 +37,6 @@ static struct cmd_builtin builtins[] = {
 		{ NULL, NULL }
 };
 
-/* Function Prototypes */
 static struct cmd_builtin *get_builtin(const char *s);
 static int run_builtin(struct cmd_builtin *builtin, int argc, char *argv[]);
 static int run_extension(const char *s, int argc, char *argv[]);
@@ -45,7 +44,6 @@ static char *find_extension(char *extension_name);
 static void show_main_usage(int err, const char *optional_message_format, ...);
 static void show_version(void);
 
-/* Public Functions */
 int main(int argc, char *argv[])
 {
 	//Show usage and return if no arguments provided
@@ -79,7 +77,7 @@ int main(int argc, char *argv[])
 			return status;
 		}
 
-		show_main_usage(1, "error: unknown command '%s'", argv[1]);
+		show_main_usage(1, "error: unknown command or option '%s'", argv[1]);
 		return 1;
 	}
 
@@ -113,7 +111,7 @@ static int run_extension(const char *s, int argc, char *argv[])
 	child_process_def_init(&cmd);
 	cmd.executable = s;
 	for (size_t i = 0; i < argc; i++)
-		argv_array_push(&cmd.args, argv[i]);
+		argv_array_push(&cmd.args, argv[i], NULL);
 
 	int status = run_command(&cmd);
 	child_process_def_release(&cmd);

--- a/src/run-command.c
+++ b/src/run-command.c
@@ -3,8 +3,8 @@
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 
 #include "run-command.h"
@@ -224,8 +224,8 @@ static int exec_as_child_process(struct child_process_def *cmd, int capture,
 static inline void set_cloexec(int fd)
 {
 	int flags = fcntl(fd, F_GETFD);
-	if (flags >= 0)
-		fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+	if (flags < 0 || fcntl(fd, F_SETFD, flags | FD_CLOEXEC) < 0)
+		FATAL("fcntl() failed unexpectedly.");
 }
 
 /**
@@ -258,9 +258,8 @@ static void merge_env(struct str_array *deltaenv, struct str_array *result)
 	if (result->len)
 		BUG("merge_env() accepts an empty str_array as an argument, but given str_array was not empty.");
 
-	while (*parent_env) {
+	while (*parent_env)
 		str_array_push(&current_env, *(parent_env++), NULL);
-	}
 
 	for (size_t i = 0; i < deltaenv->len; i++)
 		str_array_insert(result, deltaenv->strings[i], i);

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -37,13 +37,13 @@ void strbuf_grow(struct strbuf *buff, size_t size)
 		FATAL(MEM_ALLOC_FAILED);
 }
 
-void strbuf_attach(struct strbuf *buff, char *str, size_t buffer_len)
+void strbuf_attach(struct strbuf *buff, const char *str, size_t buffer_len)
 {
 	char *eos = memchr(str, 0, buffer_len);
 	size_t str_len = (eos == NULL) ? buffer_len : (size_t)(eos - str);
 
 	if ((buff->len + str_len + 1) >= buff->alloc)
-		strbuf_grow(buff, buffer_len + BUFF_SLOP);
+		strbuf_grow(buff, buff->alloc + buffer_len + BUFF_SLOP);
 
 	strncpy(buff->buff + buff->len, str, str_len);
 	buff->buff[buff->len + str_len] = 0;
@@ -51,7 +51,7 @@ void strbuf_attach(struct strbuf *buff, char *str, size_t buffer_len)
 	buff->len += str_len;
 }
 
-void strbuf_attach_str(struct strbuf *buff, char *str)
+void strbuf_attach_str(struct strbuf *buff, const char *str)
 {
 	strbuf_attach(buff, str, strlen(str));
 }

--- a/src/usage.c
+++ b/src/usage.c
@@ -53,13 +53,13 @@ void show_options(const struct option_description *opts, int err)
 
 		if (opt.type == OPTION_GROUP_T) {
 			if (index > 1)
-				fprintf(stdout, "\n");
+				fprintf(fp, "\n");
 
-			fprintf(stdout, "%s\n", opt.desc);
+			fprintf(fp, "%s:\n", opt.desc);
 			continue;
 		}
 
-		printed_chars += fprintf(fp, "	");
+		printed_chars += fprintf(fp, "    ");
 		if (opt.type == OPTION_BOOL_T) {
 			if (opt.s_flag)
 				printed_chars += fprintf(fp, "-%c", opt.s_flag);
@@ -254,3 +254,4 @@ int is_valid_argument(const char *arg,
 
 	return false;
 }
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,7 +16,7 @@ ADD_TEST(NAME unit-tests COMMAND ${PROJECT_NAME}-unit-tests)
 #
 # Configure Integration Tests
 #
-FIND_PROGRAM(BASH_INTERPRETER sh)
+FIND_PROGRAM(BASH_INTERPRETER bash)
 ADD_CUSTOM_TARGET(${PROJECT_NAME}-integration-tests)
 ADD_CUSTOM_COMMAND(TARGET ${PROJECT_NAME}-integration-tests COMMAND ${BASH_INTERPRETER} "${PROJECT_BINARY_DIR}/test/integration-runner.sh")
 


### PR DESCRIPTION
Various minor improvements to the codebase. The most notable changes are
the following:
- the sentinel function attribute was added to functions that expect
variadic arguments with a NULL pointer terminating the args. This will
help reduce developer error.
- renamed various usage strings
- ensure that fs-utils is_executable is idempotent on the errno.
- renamed file pointers from fd to fp.
- cmake now runs the integration test suite in bash, rather than sh.
This is needed, since sh is not a platform agnostic way of running
scripts.
- Fixed bug around strbuf_attach that would cause it to fail when
attaching large strings, since the buffer was not growing correctly.
- Added const keyword where appropriate.