### PR TITLE
Improvements to git-chat-init

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -64,4 +64,15 @@ void WARN(const char *fmt, ...);
  * */
 void set_exit_routine(NORETURN void (*new_exit_routine)(int status));
 
+/**
+ * Determine whether the current working directory is a valid git-chat space.
+ *
+ * The current working directory is a git-chat space if the following conditions
+ * are met:
+ * - `.git-chat` exists and is a directory
+ * - `.git` exists and is a directory
+ * - `git rev-parse --is-inside-work-tree` returns with a zero exit status
+ * */
+int is_inside_git_chat_space();
+
 #endif //GIT_CHAT_UTILS_H

--- a/src/builtin/init.c
+++ b/src/builtin/init.c
@@ -23,10 +23,10 @@ static const struct usage_description init_cmd_usage[] = {
 };
 
 static const struct option_description init_cmd_options[] = {
-		OPT_STRING('n', "name", "name", "Specify a name for the master channel"),
-		OPT_STRING('d', "description", "desc", "Specify a description for the space"),
-		OPT_BOOL('q', "quiet", "Only print error and warning messages"),
-		OPT_BOOL('h', "help", "Show usage and exit"),
+		OPT_STRING('n', "name", "name", "specify a name for the master channel"),
+		OPT_STRING('d', "description", "desc", "specify a description for the space"),
+		OPT_BOOL('q', "quiet", "only print error and warning messages"),
+		OPT_BOOL('h', "help", "show usage and exit"),
 		OPT_END()
 };
 
@@ -49,19 +49,29 @@ int cmd_init(int argc, char *argv[])
 		char *arg = argv[arg_index];
 
 		if (!is_valid_argument(arg, init_cmd_options)) {
-			show_init_usage(1, "error: unknown flag '%s'", arg);
+			show_init_usage(1, "error: unknown option '%s'", arg);
 			return 1;
 		}
 
 		//room name
 		if (argument_matches_option(arg, init_cmd_options[0])) {
-			channel_name = argv[++arg_index];
+			if (++arg_index >= argc) {
+				show_init_usage(1, "error: no channel name provided with %s", arg);
+				return 1;
+			}
+
+			channel_name = argv[arg_index];
 			continue;
 		}
 
 		//room description
 		if (argument_matches_option(arg, init_cmd_options[1])) {
-			room_desc = argv[++arg_index];
+			if (++arg_index >= argc) {
+				show_init_usage(1, "error: no room description provided with %s", arg);
+				return 1;
+			}
+
+			room_desc = argv[arg_index];
 			continue;
 		}
 
@@ -85,6 +95,9 @@ static int init(const char *channel_name, const char *space_desc, const int quie
 {
 	struct child_process_def cmd;
 	child_process_def_init(&cmd);
+
+	if (is_inside_git_chat_space())
+		DIE("A git-chat space cannot be reinitialized.");
 
 	LOG_INFO("Initializing new space '%s' with master channel name '%s'",
 			space_desc, channel_name);
@@ -122,43 +135,49 @@ static int init(const char *channel_name, const char *space_desc, const int quie
 
 	// create .keys directory
 	safe_create_dir(cwd_path_buf.buff, ".keys");
+	LOG_INFO("Created .keys directory");
 
-	//recursively copy from template dir into .cache
-	struct strbuf cache_path;
-	strbuf_init(&cache_path);
-	strbuf_attach_fmt(&cache_path, "%s/.cache", cwd_path_buf.buff);
-	copy_dir(DEFAULT_GIT_CHAT_TEMPLATES_DIR, cache_path.buff);
-	LOG_INFO("Copied directory from " DEFAULT_GIT_CHAT_TEMPLATES_DIR " to '%s'",
-			 cache_path.buff);
+	// create .keys directory
+	safe_create_dir(cwd_path_buf.buff, ".git/chat-cache");
+	LOG_INFO("Created .git/chat-cache directory");
+
+	//recursively copy from template dir into .git-chat
+	struct strbuf git_chat_path;
+	strbuf_init(&git_chat_path);
+	strbuf_attach_fmt(&git_chat_path, "%s/.git-chat", cwd_path_buf.buff);
+	copy_dir(DEFAULT_GIT_CHAT_TEMPLATES_DIR, git_chat_path.buff);
+	LOG_INFO("Copied directory from '" DEFAULT_GIT_CHAT_TEMPLATES_DIR "' to '%s'",
+			 git_chat_path.buff);
 
 	struct strbuf author;
 	strbuf_init(&author);
 
 	char *author_str = NULL;
-	if (!get_author_identity(&author))
+	if (!get_author_identity(&author)) {
 		author_str = author.buff;
-	else
+		LOG_INFO("Found user details (%s) from global .gitconfig", author_str);
+	} else
 		WARN("Unable to retrieve your user information. Is your user configured through .gitconfig?");
 
-	update_config(cache_path.buff, channel_name, author_str);
-	update_space_description(cache_path.buff, space_desc);
+	update_config(git_chat_path.buff, channel_name, author_str);
+	update_space_description(git_chat_path.buff, space_desc);
 
-	initialize_channel_root(cache_path.buff);
+	initialize_channel_root(git_chat_path.buff);
 
 	if (!quiet)
 		fprintf(stdout, "Successfully initialized git-chat space.\n");
 
 	strbuf_release(&author);
 	strbuf_release(&cwd_path_buf);
-	strbuf_release(&cache_path);
+	strbuf_release(&git_chat_path);
 
 	return 0;
 }
 
 /**
- * Update the channel name and channel creator in .cache/config.
+ * Update the channel name and channel creator in .git-chat/config.
  *
- * The argument 'base' is a full path to the .cache directory.
+ * The argument 'base' is a full path to the .git-chat directory.
  * */
 static void update_config(char *base, const char *channel_name, const char *author)
 {
@@ -200,12 +219,14 @@ static void update_config(char *base, const char *channel_name, const char *auth
 	write_config(&conf, config_path.buff);
 	strbuf_release(&config_path);
 	release_config_resources(&conf);
+
+	LOG_INFO("Updated master channel configuration");
 }
 
 /**
- * Update the description of the space by writing to .cache/description.
+ * Update the description of the space by writing to .git-chat/description.
  *
- * The argument 'base' is a full path to the .cache directory.
+ * The argument 'base' is a full path to the .git-chat directory.
  * */
 static void update_space_description(char *base, const char *description)
 {
@@ -283,14 +304,16 @@ static void initialize_channel_root(char *base)
 		DIE("unable to create initial commit; git exited with status %d", ret);
 
 	child_process_def_release(&cmd);
+
+	LOG_INFO("Successfully created channel root commit");
 }
 
 /**
  * Attempt to fetch the user identify from their .gitconfig. The author's name
  * is chosen, in the following order:
  * 1. user.username
- * 2. user.name
- * 3. user.email
+ * 2. user.email
+ * 3. user.name
  *
  * If none of these are available (i.e. git returns a status of 1 for all three),
  * then this function returns 1. Otherwise, returns 0 and populates the given
@@ -316,12 +339,12 @@ int get_author_identity(struct strbuf *result)
 		return 0;
 	}
 
-	//then user.name
+	//then user.email
 	strbuf_release(&cmd_out);
 	strbuf_init(&cmd_out);
 	child_process_def_init(&cmd);
 	cmd.git_cmd = 1;
-	argv_array_push(&cmd.args, "config", "--get", "user.name", NULL);
+	argv_array_push(&cmd.args, "config", "--get", "user.email", NULL);
 	ret = capture_command(&cmd, &cmd_out);
 	child_process_def_release(&cmd);
 	if (!ret) {
@@ -331,12 +354,12 @@ int get_author_identity(struct strbuf *result)
 		return 0;
 	}
 
-	//then user.email
+	//then user.name
 	strbuf_release(&cmd_out);
 	strbuf_init(&cmd_out);
 	child_process_def_init(&cmd);
 	cmd.git_cmd = 1;
-	argv_array_push(&cmd.args, "config", "--get", "user.email", NULL);
+	argv_array_push(&cmd.args, "config", "--get", "user.name", NULL);
 	ret = capture_command(&cmd, &cmd_out);
 	child_process_def_release(&cmd);
 	if (!ret) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -3,8 +3,11 @@
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
+#include <sys/stat.h>
 
 #include "utils.h"
+#include "run-command.h"
+#include "argv-array.h"
 
 static void print_message(FILE *output_stream, const char *prefix,
 		const char *fmt, va_list varargs);
@@ -76,4 +79,38 @@ void set_exit_routine(NORETURN void (*new_exit_routine)(int))
 static NORETURN void default_exit_routine(int status)
 {
 	exit(status);
+}
+
+int is_inside_git_chat_space()
+{
+	int errsv = errno;
+
+	struct stat sb;
+	if (stat(".git-chat", &sb) == -1 || !S_ISDIR(sb.st_mode)) {
+		LOG_DEBUG("Cannot stat .git-chat directory; %s", strerror(errno));
+		errno = errsv;
+		return 0;
+	}
+
+	if (stat(".git", &sb) == -1 || !S_ISDIR(sb.st_mode)) {
+		LOG_DEBUG("Cannot stat .git directory; %s", strerror(errno));
+		errno = errsv;
+		return 0;
+	}
+
+	struct child_process_def cmd;
+	child_process_def_init(&cmd);
+	cmd.git_cmd = 1;
+	cmd.no_in = 1;
+	cmd.no_out = 1;
+	cmd.no_err = 1;
+	argv_array_push(&cmd.args, "rev-parse", "--is-inside-work-tree", NULL);
+
+	//if 'git rev-parse --is-inside-work-tree' return with a zero exit status,
+	//its safe enough to assume we are in a git-chat space.
+	int status = run_command(&cmd);
+	child_process_def_release(&cmd);
+
+	errno = errsv;
+	return status == 0;
 }

--- a/test/integration/t003-git-chat-init.sh
+++ b/test/integration/t003-git-chat-init.sh
@@ -6,14 +6,123 @@ assert_success 'git chat init -h should exit with status 0' '
 	git-chat init -h
 '
 
-assert_success 'git chat init -h should exit with status 0' '
+assert_success 'git chat init -h should display usage info' '
+	reset_trash_dir
+' '
 	git-chat init -h | grep '\''^usage: git chat init'\''
 '
 
-assert_success 'git chat init should initialize empty git directory' '
+assert_success 'git chat init with unknown flag should exit with status 1 and print useful message' '
+	reset_trash_dir
+' '
+	git chat init --test 2>err
+	test "$?" = "1" &&
+	grep "error: unknown option '\''--test'\''" err
+'
+
+assert_success 'git chat init should initialize empty git repository' '
 	reset_trash_dir
 ' '
 	git chat init >out &&
 	grep "Initialized empty Git repository" out &&
 	grep "Successfully initialized git-chat space." out
+'
+
+assert_success 'reinitializing a git-chat space should not overwrite .git-chat or .keys directory' '
+	reset_trash_dir
+' '
+	git chat init &&
+	echo "my space" >>.git-chat/description &&
+	echo "my keys" >.keys/key.gpg &&
+	md5sum .git-chat/* >expected_git_chat &&
+	md5sum .keys/* >expected_keys &&
+	! git chat init &&
+	md5sum .git-chat/* >actual_git_chat &&
+	md5sum .keys/* >actual_keys &&
+	cmp -s expected_git_chat actual_git_chat &&
+	cmp -s expected_keys actual_keys
+'
+
+assert_success 'git chat init -q should not print to stdout' '
+	reset_trash_dir
+' '
+	git chat init -q >out 2>err &&
+	[ ! -s out ]
+'
+
+assert_success 'git chat init should create a single commit on master' '
+	reset_trash_dir
+' '
+	git chat init &&
+	git show --format="%s" -s >out &&
+	grep "You have reached the beginning of time." out &&
+	git rev-list --count HEAD >out
+	[ "$(cat out)" -eq "1" ]
+'
+
+assert_success 'git chat init should create the expected directory structure' '
+	reset_trash_dir
+' '
+	git chat init &&
+	[ -d ".git" ] &&
+	[ -d ".git/chat-cache" ] &&
+	[ -d ".git-chat" ] &&
+	[ -d ".keys" ] &&
+	[ -f ".git-chat/config" ] &&
+	[ -f ".git-chat/description" ]
+'
+
+assert_success 'git chat init -n with name should set the master channel name' '
+	reset_trash_dir
+' '
+	git chat init -n "test-name" &&
+	grep "name = test-name" .git-chat/config
+'
+
+assert_success 'git chat init --name with name should set the master channel name' '
+	reset_trash_dir
+' '
+	git chat init --name "test-name-2" &&
+	grep "name = test-name-2" .git-chat/config
+'
+
+assert_success 'git chat init -d with description should set the space description' '
+	reset_trash_dir
+' '
+	git chat init -d "test-description" &&
+	[ "$(cat .git-chat/description)" == "test-description" ]
+'
+
+assert_success 'git chat init --description with description should set the space description' '
+	reset_trash_dir
+' '
+	git chat init --description "test-description-2" &&
+	[ "$(cat .git-chat/description)" == "test-description-2" ]
+'
+
+assert_success 'git chat init should update config first with username' '
+	reset_trash_dir &&
+	git config --file ".gitconfig" user.username "test-username" &&
+	git config --file ".gitconfig" user.email "test.email@test.com" &&
+	git config --file ".gitconfig" user.name "test-name"
+' '
+	GIT_CONFIG=$(pwd)/.gitconfig GIT_CONFIG_NOSYSTEM=1 git chat init &&
+	grep "createdby = test-username" .git-chat/config
+'
+
+assert_success 'git chat init should update config with email if no username found' '
+	reset_trash_dir &&
+	git config --file ".gitconfig" user.email "test.email@test.com" &&
+	git config --file ".gitconfig" user.name "test-name"
+' '
+	GIT_CONFIG=$(pwd)/.gitconfig GIT_CONFIG_NOSYSTEM=1 git chat init &&
+	grep "createdby = test.email@test.com" .git-chat/config
+'
+
+assert_success 'git chat init should update config with name if no username or email found' '
+	reset_trash_dir &&
+	git config --file ".gitconfig" user.name "test-name"
+' '
+	GIT_CONFIG=$(pwd)/.gitconfig GIT_CONFIG_NOSYSTEM=1 git chat init &&
+	grep "createdby = test-name" .git-chat/config
 '

--- a/test/integration/t003-git-chat-init.sh
+++ b/test/integration/t003-git-chat-init.sh
@@ -90,14 +90,14 @@ assert_success 'git chat init -d with description should set the space descripti
 	reset_trash_dir
 ' '
 	git chat init -d "test-description" &&
-	[ "$(cat .git-chat/description)" == "test-description" ]
+	[ "$(cat .git-chat/description)" = "test-description" ]
 '
 
 assert_success 'git chat init --description with description should set the space description' '
 	reset_trash_dir
 ' '
 	git chat init --description "test-description-2" &&
-	[ "$(cat .git-chat/description)" == "test-description-2" ]
+	[ "$(cat .git-chat/description)" = "test-description-2" ]
 '
 
 assert_success 'git chat init should update config first with username' '

--- a/test/integration/t003-git-chat-init.sh
+++ b/test/integration/t003-git-chat-init.sh
@@ -34,11 +34,11 @@ assert_success 'reinitializing a git-chat space should not overwrite .git-chat o
 	git chat init &&
 	echo "my space" >>.git-chat/description &&
 	echo "my keys" >.keys/key.gpg &&
-	md5sum .git-chat/* >expected_git_chat &&
-	md5sum .keys/* >expected_keys &&
+	shasum .git-chat/* >expected_git_chat &&
+	shasum .keys/* >expected_keys &&
 	! git chat init &&
-	md5sum .git-chat/* >actual_git_chat &&
-	md5sum .keys/* >actual_keys &&
+	shasum .git-chat/* >actual_git_chat &&
+	shasum .keys/* >actual_keys &&
 	cmp -s expected_git_chat actual_git_chat &&
 	cmp -s expected_keys actual_keys
 '

--- a/test/integration/test-lib.sh
+++ b/test/integration/test-lib.sh
@@ -103,6 +103,6 @@ assert_failure () {
 }
 
 reset_trash_dir () {
-	rm -rf ./{*,.*}
+	rm -rf ..?* .[!.]* *
 	return 0
 }


### PR DESCRIPTION
There were issues around git-chat-init that surfaced after further dev
testing. For instance, reinitializing a git-chat space would cause a
error with a vague error message "Bad file descriptor".

Furthermore, arguments were not correctly checked for invalid input.

Renamed .cache directory to .git-chat. Also, now .git directory contains
chat-cache directory that will later be used by git-chat for caching
temporary files, like the gpg keyring.