### PR TITLE
git-chat-message bug fix

### DIFF
--- a/src/builtin/message.c
+++ b/src/builtin/message.c
@@ -234,7 +234,7 @@ static void compose_message(struct strbuf *buff)
 	const char *msg_compose_file = path_buff.buff;
 
 	// clear the contents of GC_EDITMSG
-	int fd = open(msg_compose_file, O_WRONLY | O_TRUNC);
+	int fd = open(msg_compose_file, O_WRONLY | O_TRUNC | O_CREAT);
 	if (fd < 0)
 		FATAL(FILE_OPEN_FAILED, msg_compose_file);
 	close(fd);


### PR DESCRIPTION
When creating a new message without supplying the body of the message
with the -m switch, the command would fail with a fatal error if the
GC_EDITMSG file is missing.

To work around this, added the O_CREAT flag when opening the file, which
will create the file if missing.