### PR TITLE
Git chat config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,7 @@ RUN apt-get update && apt-get install -y \
 	vim \
 	wget
 
+RUN git config --global --add user.name "Test User" && \
+	git config --global --add user.email "testusr@integration.com"
+
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -140,6 +140,26 @@ configuring message:
 ### git chat get
 **IN PROGRESS** Fetch any new messages from the remote repository.
 
+### git chat config
+```
+usage: git chat config [--get] <key>
+   or: git chat config --get-or-default <key>
+   or: git chat config --set <key> <value>
+   or: git chat config --unset <key>
+   or: git chat config (--is-valid-key <key>) | --is-valid-config
+   or: git chat config (-e | --edit)
+   or: git chat config (-h | --help)
+
+    --get               get config value with the given key
+    --get-or-default    get config value with the given key, or default value if not present
+    --set               create or mutate config value
+    --unset             delete config value with the given key
+    --is-valid-key      exit with 0 if the key is valid
+    --is-valid-config   exit with 0 if the config is valid
+    -e, --edit          open an editor to edit the config file
+    -h, --help          show usage and exit
+```
+
 ## Extending git-chat
 git-chat follows a similar extension model to Git, where executables located on the PATH that are prefixed with `git-chat-` will be invoked when `git chat <extension name>` is run at the command line. This allows you to build custom plugins to git-chat, extending it to work for you!
 

--- a/docs/git-chat-config.1
+++ b/docs/git-chat-config.1
@@ -1,0 +1,183 @@
+.TH git-chat-config 1 "@CMAKE_COMPILATION_DATE@" "git-chat @CMAKE_PROJECT_VERSION_MAJOR@.@CMAKE_PROJECT_VERSION_MINOR@" "git-chat manual"
+
+.SH NAME
+git-chat-config \- Configure the current channel
+
+.SH SYNOPSIS
+.sp
+.nf
+\fIgit chat config\fR [\-\-get] <key>
+\fIgit chat config\fR \-\-get\-or\-default <key>
+\fIgit chat config\fR \-\-set <key> <value>
+\fIgit chat config\fR \-\-unset <key>
+\fIgit chat config\fR (\-\-is\-valid\-key <key>) | \-\-is\-valid\-config
+\fIgit chat config\fR (\-e | \-\-edit)
+\fIgit chat config\fR (\-h | \-\-help)
+
+
+.SH DESCRIPTION
+Configure the properties of a git-chat channel by manipulating its \fI/git-chat/config\fR.
+
+This command can be used to query, add, replace and remove configuration keys from the channel config file. This command can also be used for validating the syntax of the config file, and to verify that all config keys are recognized by git-chat.
+
+
+.SH OPTIONS
+.TP
+\-\-get <key>
+Get the value for a given config key in the git-chat config file. If no config exists with the given key, the terminates with an exit status of 1.
+
+.TP
+\-\-get\-or\-default <key>
+Get the value for a given config key in the git-chat config file, or a default value if the key is recognized by git-chat. Terminates with a non-zero status if the key does not exist and the provided key is not recognized by git-chat.
+
+.TP
+\-\-set <key> <value>
+Create, or update, a config key in the git-chat config file, and assign it the given value. Exits with a non-zero status if the key could not be set for any reason.
+
+.TP
+\-\-unset <key>
+Remove a key from the git-chat config file. Exits with a zero status if the key was successfully removed, and non-zero if the key does not exist or could not be removed.
+
+.TP
+\-\-is\-valid\-key <key>
+Exit with a zero status if the given key is recognized by git-chat, and non-zero otherwise.
+
+.TP
+\-\-is\-valid\-config
+Validate the git-chat config file for the current channel for syntax errors. If invalid, exits with a non-zero status.
+
+.TP
+\-e, \-\-edit
+Open the git-chat config file in Vim.
+
+.TP
+\-h, \-\-help
+Print a simple synopsis and exit.
+
+
+.SH CONFIG FILE FORMAT
+The config file has a format similar to INI or TOML, but simplified. It consists of key-value pairs organized in sections. For example:
+
+.PP
+.in +4n
+.EX
+[ section_a ]
+    key_1 = value
+    key_2 = valueb
+[ section_b ]
+    key_1 = 123
+    key_a = 321
+.EE
+.in
+.PP
+
+.SP
+.SS Whitespace Rules
+.SP
+Leading and trailing whitespace is ignored. So, the following two examples are equivalent:
+
+.PP
+.in +4n
+.EX
+[ section_a ]
+    key_1 = value
+    key_2 = valueb
+
+[ section_b ]
+key_1 = 123
+key_a = 321
+.EE
+.in
+.PP
+
+Furthermore, whitespace between the key name and `=`, and between `=` and the value is ignored. So, these statements are equivalent:
+
+.PP
+.in +4n
+.EX
+key_1 = 123
+key_1=	123
+key_1=123
+.EE
+.in
+.PP
+
+Trailing whitespace in config values are also ignored. If the value for the key must contain leading or trailing whitespace, it can be quoted with single or double quotes. Config values must not wrap multiple lines.
+
+.SP
+.SS Sections
+.SP
+Key-value pairs can be defined outside of a section, but must appear before any section declaration:
+
+.PP
+.in +4n
+.EX
+key_3 = valuec
+[ section_a ]
+    key_1 = value
+    key_2 = valueb
+.EE
+.in
+.PP
+
+Although sections cannot be nested, section names can have a period `.`, which can be used to help indicate that the section is be represented as a subsection:
+
+.PP
+.in +4n
+.EX
+[ section ]
+    key_1 = value
+[ section.subsection ]
+    key_2 = value
+.EE
+.in
+.PP
+
+Section and key names may only contain alphanumeric characters, underscores `_`, and periods `.`. Use of disallowed characters may result in undesired or undefined behavior.
+Duplicate section names are allowed, but duplicate addresses will result in undefined behavior. For instance, the following is disallowed because the address `section_a.key_1` is defined twice:
+
+.PP
+.in +4n
+.EX
+[ section_a ]
+    key_1 = value
+    key_2 = valueb
+[ section_a ]
+    key_1 = 123
+    key_a = 321
+.EE
+.in
+.PP
+
+.SP
+.SS Key-Value Pairs
+.SP
+Key-value pairs take the form `<key> = <value>`. Values in the config file are addressed using the dot ".", as shown below:
+
+.PP
+.in +4n
+.EX
+[ section_a ]
+    key_1 = value
+    key_2 = valueb
+[ section_b ]
+    key_a = 123
+    key_b = 321
+
+section_a.key_1
+section_b.key_a
+.EE
+.in
+.PP
+
+
+.SH SEE ALSO
+\fBgit-chat-init\fR(1)
+
+
+.SH REPORTING BUGS
+@DOCS_REPORTING_BUGS_SECTION@
+
+
+.SH AUTHOR
+@DOCS_AUTHORS_SECTION@

--- a/include/config-defaults.h
+++ b/include/config-defaults.h
@@ -1,0 +1,26 @@
+#ifndef GIT_CHAT_CONFIG_DEFAULTS_H
+#define GIT_CHAT_CONFIG_DEFAULTS_H
+
+#include <stdlib.h>
+
+struct config_def {
+	const char *key_pattern;
+	const char *default_value;
+};
+
+/**
+ * Fetch from the default configuration definitions the statically-allocated
+ * default value for a given key.
+ *
+ * If found, returns the default value, otherwise returns NULL.
+ * */
+const char *get_default_config_value(const char *key);
+
+/**
+ * Determine whether a given config key is recognized by the application.
+ *
+ * If recognized, returns 1. Otherwise returns 0.
+ * */
+int is_recognized_config_key(const char *key);
+
+#endif //GIT_CHAT_CONFIG_DEFAULTS_H

--- a/include/parse-config.h
+++ b/include/parse-config.h
@@ -146,6 +146,19 @@ int parse_config(struct config_file_data *conf, const char *conf_path);
 int write_config(struct config_file_data *conf, const char *conf_path);
 
 /**
+ * Check whether a file at the given path is a valid configuration file that
+ * can be parsed by the application, optionally checking that all the keys are
+ * recognized by the application.
+ *
+ * If the config file cannot be parsed, returns -1. If the config file is
+ * invalid (has duplicate or invalid keys), returns 1. Otherwise returns zero.
+ *
+ * If recognized_keys_only is non-zero, returns 2 if the config file contains
+ * unrecognized keys.
+ * */
+int is_config_invalid(const char *conf_path, int recognized_keys_only);
+
+/**
  * Release any resources under a config_file_data structure.
  * */
 void config_file_data_release(struct config_file_data *conf);
@@ -182,5 +195,15 @@ void config_file_data_set_entry_value(struct config_entry *entry, const char *va
  * Get the key for a config entry. The string returned should not be mutated.
  * */
 char *config_file_data_get_entry_key(struct config_entry *entry);
+
+/**
+ * Check that a given key string is valid, returning zero of valid and non-zero
+ * if invalid.
+ *
+ * A valid key may:
+ * - be alphanumeric characters, including '.' and '_'
+ * - each '.' must be separated by another character
+ * */
+int is_valid_key(const char *key);
 
 #endif //GIT_CHAT_PARSE_CONFIG_H

--- a/include/strbuf.h
+++ b/include/strbuf.h
@@ -104,4 +104,14 @@ char *strbuf_detach(struct strbuf *buff);
 int strbuf_split(const struct strbuf *buff, const char *delim,
 		struct str_array *result);
 
+/**
+ * Clear all content stored under the given strbuf. The strbuf is not resized,
+ * and can be reused for other purposes.
+ *
+ * This function is particularly useful for reusing memory that was previously
+ * allocated for another purpose to avoid the overhead associated with allocating
+ * and freeing memory.
+ * */
+void strbuf_clear(struct strbuf *buff);
+
 #endif //GIT_CHAT_STRBUF_H

--- a/src/builtin/config.c
+++ b/src/builtin/config.c
@@ -1,11 +1,280 @@
+#include <stdio.h>
 
 #include "parse-options.h"
+#include "parse-config.h"
+#include "config-defaults.h"
+#include "run-command.h"
+#include "fs-utils.h"
 #include "utils.h"
 
-/**
- * Features:
- * - Editing git-chat config for the channel
- * - Listing GPG keys in the keyring
- * - Importing GPG key into keyring
- * */
+static struct usage_string usage[] = {
+		USAGE("git chat config [--get] <key>"),
+		USAGE("git chat config --get-or-default <key>"),
+		USAGE("git chat config --set <key> <value>"),
+		USAGE("git chat config --unset <key>"),
+		USAGE("git chat config (--is-valid-key <key>) | --is-valid-config"),
+		USAGE("git chat config (-e | --edit)"),
+		USAGE("git chat config (-h | --help)"),
+		USAGE_END()
+};
 
+static int config_query_value(const char *, int);
+static int config_set_value(const char *, const char *);
+static int editor_edit_config_file();
+static int is_config_file_valid();
+
+int cmd_config(int argc, char *argv[])
+{
+	int get_value = 0;
+	int get_or_default = 0;
+	int set_value = 0;
+	int unset_value = 0;
+	int edit = 0;
+	int validate_key = 0;
+	int is_valid_config = 0;
+	int show_help = 0;
+
+	const struct command_option config_cmd_options[] = {
+			OPT_LONG_BOOL("get", "get config value with the given key", &get_value),
+			OPT_LONG_BOOL("get-or-default", "get config value with the given key, or default value if not present", &get_or_default),
+			OPT_LONG_BOOL("set", "create or mutate config value", &set_value),
+			OPT_LONG_BOOL("unset", "delete config value with the given key", &unset_value),
+			OPT_LONG_BOOL("is-valid-key", "exit with 0 if the key is valid", &validate_key),
+			OPT_LONG_BOOL("is-valid-config", "exit with 0 if the config is valid", &is_valid_config),
+			OPT_BOOL('e', "edit", "open an editor to edit the config file", &edit),
+			OPT_BOOL('h', "help", "show usage and exit", &show_help),
+			OPT_END()
+	};
+
+	argc = parse_options(argc, argv, config_cmd_options, 1, 1);
+	if (show_help) {
+		show_usage_with_options(usage, config_cmd_options, 0, NULL);
+		return 0;
+	}
+
+	int opts = 0;
+	if (get_value)
+		opts++;
+	if (get_or_default)
+		opts++;
+	if (set_value)
+		opts++;
+	if (unset_value)
+		opts++;
+	if (edit)
+		opts++;
+	if (validate_key)
+		opts++;
+	if (is_valid_config)
+		opts++;
+
+	if (opts > 1) {
+		show_usage_with_options(usage, config_cmd_options, 1, "error: unexpected combination of options");
+		return 1;
+	}
+	if (opts == 0)
+		get_value = 1;
+
+	if (get_value || get_or_default) {
+		if (argc != 1) {
+			show_usage_with_options(usage, config_cmd_options, 1, "error: wrong number of arguments, expected single config key");
+			return 1;
+		}
+
+		return config_query_value(argv[0], get_or_default);
+	}
+
+	if (set_value) {
+		if (argc != 2) {
+			show_usage_with_options(usage, config_cmd_options, 1, "error: wrong number of arguments, expected config key and value");
+			return 1;
+		}
+
+		return config_set_value(argv[0], argv[1]);
+	}
+
+	if (unset_value) {
+		if (argc != 1) {
+			show_usage_with_options(usage, config_cmd_options, 1, "error: wrong number of arguments, expected single config key");
+			return 1;
+		}
+
+		return config_set_value(argv[0], NULL);
+	}
+
+	if (validate_key) {
+		if (argc != 1) {
+			show_usage_with_options(usage, config_cmd_options, 1, "error: wrong number of arguments, expected single config key");
+			return 1;
+		}
+
+		return !(is_recognized_config_key(argv[0]) && is_valid_key(argv[0]));
+	}
+
+	if (is_valid_config) {
+		if (argc != 0) {
+			show_usage_with_options(usage, config_cmd_options, 1, "error: too many arguments");
+			return 1;
+		}
+
+		return !is_config_file_valid();
+	}
+
+	if (edit) {
+		if (argc) {
+			show_usage_with_options(usage, config_cmd_options, 1, "error: too many options with --edit");
+			return 1;
+		}
+
+		return editor_edit_config_file();
+	}
+
+	return 1;
+}
+
+static int config_query_value(const char *key, int fallback_default)
+{
+	if (!is_inside_git_chat_space())
+		DIE("Where are you? It doesn't look like you're in the right directory.");
+
+	struct strbuf cwd_path_buf;
+	strbuf_init(&cwd_path_buf);
+	if (get_cwd(&cwd_path_buf))
+		FATAL("unable to obtain the current working directory from getcwd()");
+
+	struct strbuf config_path;
+	strbuf_init(&config_path);
+	strbuf_attach_fmt(&config_path, "%s/.git-chat/config", cwd_path_buf.buff);
+
+	struct config_file_data conf;
+	int ret = parse_config(&conf, config_path.buff);
+	if (ret < 0)
+		DIE("unable to query config from '%s'; cannot access file", config_path);
+	if (ret > 0)
+		DIE("unable to query config from '%s'; file contains syntax errors", config_path);
+
+	struct config_entry *entry = config_file_data_find_entry(&conf, key);
+	if (entry)
+		fprintf(stdout, "%s\n", config_file_data_get_entry_value(entry));
+
+	strbuf_release(&config_path);
+	strbuf_release(&cwd_path_buf);
+	config_file_data_release(&conf);
+
+	// if no entry was found, and fallback on default, then show default value
+	if (!entry && fallback_default) {
+		const char *default_val = get_default_config_value(key);
+		if (!default_val)
+			return 1;
+
+		fprintf(stdout, "%s\n", default_val);
+		return 0;
+	}
+
+	return entry == NULL;
+}
+
+static int config_set_value(const char *key, const char *value)
+{
+	if (!is_inside_git_chat_space())
+		DIE("Where are you? It doesn't look like you're in the right directory.");
+
+	struct strbuf cwd_path_buf;
+	strbuf_init(&cwd_path_buf);
+	if (get_cwd(&cwd_path_buf))
+		FATAL("unable to obtain the current working directory from getcwd()");
+
+	struct strbuf config_path;
+	strbuf_init(&config_path);
+	strbuf_attach_fmt(&config_path, "%s/.git-chat/config", cwd_path_buf.buff);
+
+	struct config_file_data conf;
+	int ret = parse_config(&conf, config_path.buff);
+	if (ret < 0)
+		FATAL("unable to update config '%s'; cannot access file", config_path);
+	if (ret > 0)
+		DIE("malformed config file '%s'", config_path);
+
+	struct config_entry *entry = config_file_data_find_entry(&conf, key);
+	if (!value) {
+		// unset config
+		if (entry)
+			config_file_data_delete_entry(&conf, entry);
+		else
+			WARN("config with key '%s' does not exist", key);
+	} else if (!entry) {
+		// create if entry doesn't exist
+		if (!config_file_data_insert_entry(&conf, key, value))
+			DIE("invalid config key '%s'", key);
+	} else {
+		// set value if exists
+		config_file_data_set_entry_value(entry, value);
+	}
+
+	ret = write_config(&conf, config_path.buff);
+	if (ret < 0)
+		FATAL("failed to open destination file '%s' for writing", config_path.buff);
+	if (ret > 0)
+		DIE("could not write malformed config", config_path.buff);
+
+	strbuf_release(&config_path);
+	strbuf_release(&cwd_path_buf);
+	config_file_data_release(&conf);
+
+	// return 1 if --unset and entry not found
+	return !value && !entry;
+}
+
+static int editor_edit_config_file()
+{
+	if (!is_inside_git_chat_space())
+		DIE("Where are you? It doesn't look like you're in the right directory.");
+
+	struct strbuf cwd_path_buf;
+	strbuf_init(&cwd_path_buf);
+	if (get_cwd(&cwd_path_buf))
+		FATAL("unable to obtain the current working directory from getcwd()");
+
+	struct strbuf config_path;
+	strbuf_init(&config_path);
+	strbuf_attach_fmt(&config_path, "%s/.git-chat/config", cwd_path_buf.buff);
+
+	struct child_process_def cmd;
+	child_process_def_init(&cmd);
+	cmd.executable = "vim";
+	argv_array_push(&cmd.args, "-c", "set nobackup nowritebackup", "-n",
+			config_path.buff, NULL);
+
+	int status = run_command(&cmd);
+	if (status)
+		DIE("Vim editor failed with exit status '%d'", status);
+
+	child_process_def_release(&cmd);
+
+	strbuf_release(&config_path);
+	strbuf_release(&cwd_path_buf);
+
+	return 0;
+}
+
+static int is_config_file_valid()
+{
+	if (!is_inside_git_chat_space())
+		DIE("Where are you? It doesn't look like you're in the right directory.");
+
+	struct strbuf cwd_path_buf;
+	strbuf_init(&cwd_path_buf);
+	if (get_cwd(&cwd_path_buf))
+		FATAL("unable to obtain the current working directory from getcwd()");
+
+	struct strbuf config_path;
+	strbuf_init(&config_path);
+	strbuf_attach_fmt(&config_path, "%s/.git-chat/config", cwd_path_buf.buff);
+
+	int is_invalid = is_config_invalid(config_path.buff, 1);
+
+	strbuf_release(&config_path);
+	strbuf_release(&cwd_path_buf);
+
+	return !is_invalid;
+}

--- a/src/builtin/init.c
+++ b/src/builtin/init.c
@@ -182,40 +182,34 @@ static void update_config(char *base, const char *channel_name, const char *auth
 	strbuf_init(&config_path);
 	strbuf_attach_fmt(&config_path, "%s/config", base);
 
-	struct conf_data conf;
+	struct config_file_data conf;
 	int ret = parse_config(&conf, config_path.buff);
 	if (ret < 0)
 		DIE("unable to update '%s'; cannot access file", config_path);
-	else if (ret > 0)
+	if (ret > 0)
 		DIE("unable to update '%s'; file contains syntax errors", config_path);
 
 	if (channel_name) {
-		struct conf_data_entry *entry = conf_data_find_entry(&conf, "channel.master", "name");
+		struct config_entry *entry = config_file_data_find_entry(&conf, "channel.master.name");
 		if (!entry)
 			DIE("unexpected config template with missing key 'channel.master.name'");
 
 		//overwrite updated config file
-		free(entry->value);
-		entry->value = strdup(channel_name);
-		if (!entry->value)
-			FATAL(MEM_ALLOC_FAILED);
+		config_file_data_set_entry_value(entry, channel_name);
 	}
 
 	if (author) {
-		struct conf_data_entry *entry = conf_data_find_entry(&conf, "channel.master", "createdby");
+		struct config_entry *entry = config_file_data_find_entry(&conf, "channel.master.createdby");
 		if (!entry)
 			DIE("unexpected config template with missing key 'channel.master.createdby'");
 
 		//overwrite updated config file
-		free(entry->value);
-		entry->value = strdup(author);
-		if (!entry->value)
-			FATAL(MEM_ALLOC_FAILED);
+		config_file_data_set_entry_value(entry, author);
 	}
 
 	write_config(&conf, config_path.buff);
 	strbuf_release(&config_path);
-	release_config_resources(&conf);
+	config_file_data_release(&conf);
 
 	LOG_INFO("Updated master channel configuration");
 }

--- a/src/config-defaults.c
+++ b/src/config-defaults.c
@@ -1,0 +1,70 @@
+#include <string.h>
+#include <ctype.h>
+
+#include "config-defaults.h"
+
+static const struct config_def config_defaults[] = {
+		{ "channel.*.name", "" },
+		{ "channel.*.createdby", "" },
+		{ "channel.*.description", "" },
+		{ NULL }
+};
+
+static int key_matches_pattern(const char *, const char *);
+
+const char *get_default_config_value(const char *key)
+{
+	const struct config_def *config = config_defaults;
+	while (config->key_pattern) {
+		if (!strcmp(config->key_pattern, key))
+			return config->default_value;
+		if (key_matches_pattern(config->key_pattern, key))
+			return config->default_value;
+
+		config++;
+	}
+
+	return NULL;
+}
+
+int is_recognized_config_key(const char *key)
+{
+	return get_default_config_value(key) != NULL;
+}
+
+/**
+ * Determine whether a key matches a given pattern.
+ *
+ * Glob-like patterns are accepted, where '*' matches any number of alphanumeric
+ * characters.
+ *
+ * Pattern: "example.*.key"
+ * Matching: "example.section.key", "example.section123.key"
+ * Not Matching: "example.key", "example..section1.section2.key"
+ *
+ * Returns 1 if the key matches the pattern, and zero otherwise.
+ * */
+static int key_matches_pattern(const char *pattern, const char *key)
+{
+ 	size_t key_index = 0, pattern_index = 0;
+	do {
+		if ((key[key_index] != 0) != (pattern[pattern_index] != 0))
+			return 0;
+		if (key[key_index] == 0 && pattern[pattern_index] == 0)
+			break;
+
+		if (pattern[pattern_index] == '*') {
+			pattern_index++;
+			while (isalnum(key[key_index]))
+				key_index++;
+		} else {
+			if (key[key_index] != pattern[pattern_index])
+				return 0;
+
+			key_index++;
+			pattern_index++;
+		}
+	} while (1);
+
+	return 1;
+}

--- a/src/git-chat.c
+++ b/src/git-chat.c
@@ -18,6 +18,7 @@ static const struct usage_string main_cmd_usage[] = {
 
 static struct cmd_builtin builtins[] = {
 		{ "channel", cmd_channel },
+		{ "config", cmd_config },
 		{ "init", cmd_init },
 		{ "message", cmd_message },
 		{ "publish", cmd_publish },

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -202,3 +202,9 @@ int strbuf_split(const struct strbuf *buff, const char *delim, struct str_array 
 
 	return inserted;
 }
+
+void strbuf_clear(struct strbuf *buff)
+{
+	memset(buff->buff, 0, buff->alloc);
+	buff->len = 0;
+}

--- a/test/include/test-suite.h
+++ b/test/include/test-suite.h
@@ -8,5 +8,6 @@ extern int parse_config_test(struct test_runner_instance *);
 extern int run_command_test(struct test_runner_instance *);
 extern int parse_options_test(struct test_runner_instance *);
 extern int fs_utils_test(struct test_runner_instance *);
+extern int config_defaults_test(struct test_runner_instance *);
 
 #endif //GIT_CHAT_SUITE_H

--- a/test/integration/t005-git-chat-config.sh
+++ b/test/integration/t005-git-chat-config.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+
+source ./test-lib.sh
+
+assert_success 'git chat config -h should show usage info' '
+	reset_trash_dir
+' '
+	git chat config -h >out &&
+	grep '\''^usage: git chat config'\'' out
+'
+
+assert_success 'git chat config uninitialized space should fail with appropriate message' '
+	reset_trash_dir
+' '
+	! git chat config --get key 2>err &&
+	! git chat config --get key &&
+	grep "Where are you" err
+'
+
+assert_success 'git chat config --get with unknown config should print empty string' '
+	reset_trash_dir &&
+	git chat init -q
+' '
+	! git chat config --get unknown >out &&
+	[ ! -s out ]
+'
+
+assert_success 'git chat config --get with known config should print config' '
+	reset_trash_dir &&
+	git chat init -q &&
+	cat >.git-chat/config <<-\EOF
+	[ mysimpleconfig ]
+		simple = value
+	EOF
+' '
+	git chat config --get mysimpleconfig.simple >out &&
+	grep "value" out
+'
+
+assert_success 'git chat config --get should find all config entries' '
+	reset_trash_dir &&
+	git chat init -q &&
+	cat >.git-chat/config <<-\EOF
+	[ config1 ]
+		simple1 = value1
+		simple2 = value2
+	[ config2 ]
+		simple3 = value3
+		simple4 = value4
+	EOF
+' '
+	git chat config --get config1.simple1 &&
+	git chat config --get config1.simple2 &&
+	git chat config --get config2.simple3 &&
+	git chat config --get config2.simple4
+'
+
+assert_success 'git chat config --set with existing key should set the config for that key' '
+	reset_trash_dir &&
+	git chat init -q &&
+	cat >.git-chat/config <<-\EOF
+	[ config1 ]
+		simple1 = value
+		simple2 = value1
+	[ config2 ]
+		simple3 = value
+		simple4 = value1
+	EOF
+' '
+	git chat config --set config1.simple2 "new value" &&
+	grep "simple2 = new value" .git-chat/config &&
+	! grep "simple2 = value" .git-chat/config &&
+	git chat config --get config1.simple2 >out &&
+	grep "new value" out
+'
+
+assert_success 'git chat config --set with unknown key should create new config' '
+	reset_trash_dir &&
+	git chat init -q
+' '
+	git chat config --set my.config "my config value" &&
+	git chat config --get my.config >out &&
+	cat out &&
+	grep "my config value" out
+'
+
+assert_success 'git chat config --set with invalid key should fail with message' '
+	reset_trash_dir &&
+	git chat init -q
+' '
+	! git chat config --set '\''my.c$onfig.value'\'' "my config value" 2>err &&
+	grep "invalid config key" err &&
+	! git chat config --set "my.c onfig.value" "my config value" 2>err &&
+	grep "invalid config key" err &&
+	! git chat config --set my.c$onfig. "my config value" 2>err &&
+	grep "invalid config key" err &&
+	! git chat config --set my..value "my config value" 2>err &&
+	grep "invalid config key" err &&
+	! git chat config --set .my.value "my config value" 2>err &&
+	grep "invalid config key" err
+'
+
+assert_success 'git chat config --unset with unknonwn key should exit with nonzero status' '
+	! git chat config --unset unknown.config
+'
+
+assert_success 'git chat config --unset should remove the property from the file' '
+	reset_trash_dir &&
+	git chat init -q &&
+	cat >.git-chat/config <<-\EOF
+	[ config1 ]
+		simple1 = value1
+		simple2 = value2
+	[ config2 ]
+		simple3 = value3
+		simple4 = value4
+	EOF
+' '
+	git chat config --unset config1.simple1 &&
+	! grep "simple1" .git-chat/config &&
+	! grep "value1" .git-chat/config
+'
+
+assert_success 'git chat config --unset should remove section if no entries exist' '
+	reset_trash_dir &&
+	git chat init -q &&
+	cat >.git-chat/config <<-\EOF
+	[ config1 ]
+		simple1 = value1
+		simple2 = value2
+	[ config2 ]
+		simple3 = value3
+		simple4 = value4
+	EOF
+' '
+	git chat config --unset config1.simple1 &&
+	git chat config --unset config1.simple2 &&
+	! grep "config1" .git-chat/config
+'
+
+assert_success 'git chat config with invalid comibnation of options should fail' '
+	reset_trash_dir &&
+	git chat init -q &&
+	cat >.git-chat/config <<-\EOF
+	[ config1 ]
+		simple1 = value1
+		simple2 = value2
+	[ config2 ]
+		simple3 = value3
+		simple4 = value4
+	EOF
+' '
+	! git chat config --get --set config2.simple3 value &&
+	! git chat config --get --unset config1.simple2 &&
+	! git chat config --set config2.simple3 value --get-or-default config2.simple4 &&
+	! git chat config --get --get-or-default config2.simple3 &&
+	! git chat config --is-valid-config --is-valid-key channel.master.name &&
+	! git chat config --unset config2.simple3 --set config2.simple3 value &&
+	! git chat config --is-valid-config --set config2.simple3 value
+'
+
+assert_success 'git chat config --get-or-default should return default value' '
+	reset_trash_dir &&
+	git chat init -q
+' '
+	git chat config --get-or-default channel.master.name >out &&
+	grep "master" out
+'
+
+assert_success 'git chat config --is-valid-key should exit with zero status if key is valid' '
+	git chat config --is-valid-key channel.master.name &&
+	git chat config --is-valid-key channel.dev.name &&
+	git chat config --is-valid-key channel.random.name &&
+	! git chat config --is-valid-key channel.name &&
+	! git chat config --is-valid-key unknown &&
+	! git chat config --is-valid-key '\''channel.ma&ster.name'\'' &&
+	! git chat config --is-valid-key channel..name
+'
+
+assert_success 'git chat config --is-valid-config with invalid config should exit with nonzero status' '
+	reset_trash_dir &&
+	git chat init -q
+' '
+	cp $TEST_RESOURCES_DIR/bad_key_1.config .git-chat/config &&
+	! git chat config --is-valid-config &&
+	cp $TEST_RESOURCES_DIR/bad_key_2.config .git-chat/config &&
+	! git chat config --is-valid-config &&
+	cp $TEST_RESOURCES_DIR/bad_key_3.config .git-chat/config &&
+	! git chat config --is-valid-config &&
+	cp $TEST_RESOURCES_DIR/bad_key_4.config .git-chat/config &&
+	! git chat config --is-valid-config &&
+	cp $TEST_RESOURCES_DIR/bad_section_1.config .git-chat/config &&
+	! git chat config --is-valid-config &&
+	cp $TEST_RESOURCES_DIR/bad_section_2.config .git-chat/config &&
+	! git chat config --is-valid-config &&
+	cp $TEST_RESOURCES_DIR/bad_section_3.config .git-chat/config &&
+	! git chat config --is-valid-config &&
+	cp $TEST_RESOURCES_DIR/good_1.config .git-chat/config &&
+	! git chat config --is-valid-config &&
+	cp $TEST_RESOURCES_DIR/good_2.config .git-chat/config &&
+	! git chat config --is-valid-config
+'
+
+assert_success 'git chat config --is-valid-config with valid config should exit with zero status' '
+	reset_trash_dir &&
+	git chat init -q
+' '
+	cp $TEST_RESOURCES_DIR/good_3.config .git-chat/config &&
+	git chat config --is-valid-config
+'

--- a/test/resources/bad_key_1.config
+++ b/test/resources/bad_key_1.config
@@ -1,3 +1,3 @@
 [validsection]
 	validkey = valid value
-	 = valid value
+	 = invalid key valid value

--- a/test/resources/bad_key_5.config
+++ b/test/resources/bad_key_5.config
@@ -1,3 +1,0 @@
-[validsection]
-	invalidkey = valid value
-	invalidkey = valid value

--- a/test/resources/good_3.config
+++ b/test/resources/good_3.config
@@ -1,0 +1,12 @@
+[channel.master]
+    name = master
+    createdby =
+    description = General Channel
+[channel.random]
+    name = "Random Dev Stuff"
+    createdby = testuser@something.com
+    description = Stuff for random things and stuff
+[channel.dev]
+	name = "Dev Stuff"
+	createdby = testuser@something.com
+	description = things

--- a/test/runner.c
+++ b/test/runner.c
@@ -11,6 +11,7 @@ static struct suite_test tests[] = {
 		{ "run-command", run_command_test },
 		{ "parse-options", parse_options_test },
 		{ "fs-utils", fs_utils_test },
+		{ "config-defaults", config_defaults_test },
 		{ NULL, NULL }
 };
 

--- a/test/unit/config-defaults-test.c
+++ b/test/unit/config-defaults-test.c
@@ -1,0 +1,72 @@
+#include "test-lib.h"
+#include "config-defaults.h"
+
+TEST_DEFINE(config_default_get_default_value_nonexistent)
+{
+	TEST_START() {
+		const char *value = get_default_config_value("channel.name");
+		assert_null(value);
+		value = get_default_config_value("channel.testme.name1");
+		assert_null(value);
+		value = get_default_config_value("channel.a.a.name");
+		assert_null(value);
+		value = get_default_config_value("achannel.test.name");
+		assert_null(value);
+	}
+
+	TEST_END();
+}
+
+TEST_DEFINE(config_default_get_default_value_using_pattern)
+{
+	TEST_START() {
+		const char *value = get_default_config_value("channel.*.name");
+		assert_string_eq("", value);
+		value = get_default_config_value("channel.*.createdby");
+		assert_string_eq("", value);
+		value = get_default_config_value("channel.*.description");
+		assert_string_eq("", value);
+	}
+
+	TEST_END();
+}
+
+TEST_DEFINE(config_default_get_default_value_matching)
+{
+	TEST_START() {
+		const char *value = get_default_config_value("channel.master.name");
+		assert_string_eq("", value);
+		value = get_default_config_value("channel.master123.name");
+		assert_string_eq("", value);
+		value = get_default_config_value("channel.a.name");
+		assert_string_eq("", value);
+	}
+
+	TEST_END();
+}
+
+TEST_DEFINE(is_recognized_key_test)
+{
+	TEST_START() {
+		assert_nonzero(is_recognized_config_key("channel.test.createdby"));
+		assert_nonzero(is_recognized_config_key("channel.*.createdby"));
+		assert_nonzero(is_recognized_config_key("channel.testme.name"));
+		assert_zero(is_recognized_config_key("unknown"));
+		assert_zero(is_recognized_config_key("channel.test.test.name"));
+	}
+
+	TEST_END();
+}
+
+int config_defaults_test(struct test_runner_instance *instance)
+{
+	struct unit_test tests[] = {
+			{ "unrecognized config should return null", config_default_get_default_value_nonexistent },
+			{ "get_default_config_value with pattern as key should return default value", config_default_get_default_value_using_pattern },
+			{ "get_default_config_value should correcly match key against pattern", config_default_get_default_value_matching },
+			{ "is_recognized_config_key should follow similar pattern-matching to get_default_config_value", is_recognized_key_test },
+			{ NULL, NULL }
+	};
+
+	return execute_tests(instance, tests);
+}

--- a/test/unit/parse-config-test.c
+++ b/test/unit/parse-config-test.c
@@ -1,5 +1,6 @@
 #include "test-lib.h"
 #include "parse-config.h"
+#include "config-defaults.h"
 
 TEST_DEFINE(initialize_config_file_data_struct)
 {
@@ -303,6 +304,51 @@ TEST_DEFINE(parse_config_read_error)
 	TEST_END();
 }
 
+TEST_DEFINE(is_config_valid_test)
+{
+	TEST_START() {
+		assert_eq(-1, is_config_invalid("resources/unknown.config", 0));
+		assert_eq(-1, is_config_invalid("resources/unknown.config", 1));
+
+		const char *invalid_configs[] = {
+				"resources/bad_key_1.config",
+				"resources/bad_key_2.config",
+				"resources/bad_key_3.config",
+				"resources/bad_key_4.config",
+				"resources/bad_section_1.config",
+				"resources/bad_section_2.config",
+				"resources/bad_section_3.config",
+				NULL
+		};
+
+		const char **conf = invalid_configs;
+		while (*conf) {
+			int is_invalid = is_config_invalid(*conf, 0);
+			assert_eq(1, is_invalid);
+			conf++;
+		}
+
+		const char *valid_configs[] = {
+				"resources/good_1.config",
+				"resources/good_2.config",
+				"resources/good_3.config",
+				NULL
+		};
+
+		conf = valid_configs;
+		while (*conf) {
+			assert_zero(is_config_invalid(*conf, 0));
+			conf++;
+		}
+
+		assert_eq(2, is_config_invalid(valid_configs[0], 1));
+		assert_eq(2, is_config_invalid(valid_configs[1], 1));
+		assert_zero(is_config_invalid(valid_configs[2], 1));
+	}
+
+	TEST_END();
+}
+
 int parse_config_test(struct test_runner_instance *instance)
 {
 	struct unit_test tests[] = {
@@ -321,6 +367,7 @@ int parse_config_test(struct test_runner_instance *instance)
 			{ "parse_config with invalid section (trailing chars) should return non-zero", parse_config_invalid_section_trailing_characters },
 			{ "parse_config with invalid section (invalid chars) should return non-zero", parse_config_invalid_section_character },
 			{ "parse_config with unknown file (read error) should return non-zero", parse_config_read_error },
+			{ "is_config_valid should correctly identify invalid config files", is_config_valid_test },
 			{ NULL, NULL }
 	};
 

--- a/test/unit/strbuf-test.c
+++ b/test/unit/strbuf-test.c
@@ -430,6 +430,28 @@ TEST_DEFINE(strbuf_remove_length_larger_than_buffer_length_test)
 	TEST_END();
 }
 
+TEST_DEFINE(strbuf_clear_test)
+{
+	struct strbuf buf;
+	strbuf_init(&buf);
+
+	TEST_START() {
+		strbuf_attach_str(&buf, "hello");
+		strbuf_attach_str(&buf, "world");
+		assert_eq(10, buf.len);
+		size_t allocated = buf.alloc;
+
+		strbuf_clear(&buf);
+		assert_zero(buf.len);
+		assert_eq(allocated, buf.alloc);
+		assert_string_eq("", buf.buff);
+	}
+
+	strbuf_release(&buf);
+
+	TEST_END();
+}
+
 int strbuf_test(struct test_runner_instance *instance)
 {
 	struct unit_test tests[] = {
@@ -448,6 +470,7 @@ int strbuf_test(struct test_runner_instance *instance)
 			{ "removing data from beginning of strbuf should shift all bytes to the left", strbuf_remove_from_beginning_test },
 			{ "removing data from within the strbuf should remove inner portion correctly", strbuf_remove_from_within_test },
 			{ "removing data from strbuf with length larger than buffer should simply remove remaining bytes", strbuf_remove_length_larger_than_buffer_length_test },
+			{ "clearing content of a strbuf should not resize buffer but clear content", strbuf_clear_test },
 			{ NULL, NULL }
 	};
 


### PR DESCRIPTION
# Implement strbuf_clear() Function
Created a simple function that can be used to clear the content of a
strbuf. This is particularly useful for reusing allocated buffers for a
new purpose without the overhead associated with allocating and freeing
new memory.

For instance, in a loop it is no longer necessary to release the strbuf
and then reinitialize it when it is needed more than once.

# Improvements to Unit Test Library
Now that the unit test library is using goto's instead of 'break', we can
now wrap the assertions in a do while() to make sure that the semicolon
is necessary at the end of the assertion.

This also ensures that we stay consistent throughout all the tests, but
also avoid compiler warnings with unecessary semicolons at the end of
each assertion.

# Reimplemented parse-config API
The existing parse-config api wsas written in the early stages of this
project, and was needlessly restrictive. The new implementation is more
modular and easier to manipulate.

The config file data structure now uses a linked list internally, which
makes it more efficient to add and remove entries. The entry structure
was also made opaque, requiring functions to accessing string data
within. This helps separate the concerns of the caller from the
internals of parse-config.

Tests were rewritten to appropriately test the new changes.

git-chat-init was modified to use the new api.

# implemented git-chat-config