### PR TITLE
Various Improvements

### DIFF
--- a/include/fs-utils.h
+++ b/include/fs-utils.h
@@ -99,4 +99,12 @@ char *find_in_path(const char *file);
  * */
 int is_executable(const char *name);
 
+/**
+ * Configure the given file descriptor with the FD_CLOEXEC, the close-on-exec,
+ * flag, which ensures the file descriptor will automatically be closed after
+ * a successful execve(2). If the execve(2) fails, the file descriptor is left
+ * open. If left unset, the file descriptor will remain open across an execve(2).
+ * */
+void set_cloexec(int fd);
+
 #endif //GIT_CHAT_FS_UTILS_H

--- a/include/paging.h
+++ b/include/paging.h
@@ -1,0 +1,60 @@
+#ifndef GIT_CHAT_PAGING_H
+#define GIT_CHAT_PAGING_H
+
+/**
+ * paging api - the git-chat pager
+ *
+ * The paging api is a utility that allows git-chat to pipe all standard output
+ * to a paging application (like less, more, or cat) configured by the user.
+ *
+ * When paging, git-chat is in a volatile state. Any computation that is being
+ * carried out cannot be guaranteed to finish since it's possible that the
+ * user terminates the paging application, which will in turn halt the git-chat
+ * runtime. With that said, the pager is particularly useful when displaying
+ * information to the user, like message history, which doesn't rely on the
+ * completion of computational work.
+ *
+ * When paging is enabled, the git-chat standard output streams (stdout, stderr)
+ * are piped to the paging application, which is running as a child process. This
+ * means the caller is free to use write(), printf(), puts(), etc., and the output
+ * will be piped to the pager.
+ *
+ * The user can select which paging application is used through the following
+ * environment variables, defined in order of precedence:
+ * - GIT_CHAT_PAGER
+ * - GIT_PAGER
+ * - PAGER
+ *
+ * If any of those pagers are not available (i.e. cannot be found, or not executable),
+ * then git-chat will default to "less", "more", or in dire cases, "cat".
+ *
+ * paging usage:
+ *
+ * int main(void) {
+ *     // initializes the pager
+ *     pager_start();
+ *
+ *     printf("large string... is paged");
+ *     fprintf(stderr, "this is also paged");
+ *     puts("so is this!");
+ *     write(1, "and this too", 13);
+ *
+ *     // stops the pager, restoring standard streams
+ *     pager_stop();
+ * }
+ * */
+
+/**
+ * Initialize the pager.
+ *
+ * Standard output stream must by a TTY. If the underlying paging application
+ * terminates, git-chat will also exit.
+ * */
+void pager_start();
+
+/**
+ * Wait for the pager to exit, remove signal handler, and restore standard streams.
+ * */
+void pager_stop();
+
+#endif //GIT_CHAT_PAGING_H

--- a/include/paging.h
+++ b/include/paging.h
@@ -57,4 +57,10 @@ void pager_start();
  * */
 void pager_stop();
 
+/**
+ * Forceably kill the running pager. Useful if git-chat encounters an exceptional
+ * state and needs to terminate.
+ * */
+void pager_kill();
+
 #endif //GIT_CHAT_PAGING_H

--- a/include/str-array.h
+++ b/include/str-array.h
@@ -168,6 +168,11 @@ struct str_array_entry *str_array_insert_nodup(struct str_array *str_a, char *st
 void str_array_sort(struct str_array *str_a);
 
 /**
+ * Reverse the order of entries in the str_array.
+ * */
+void str_array_reverse(struct str_array *str_a);
+
+/**
  * Remove a string from a given position in the str_array.
  *
  * All subsequent entries in the array are shifted to the left to fill the gap.

--- a/include/strbuf.h
+++ b/include/strbuf.h
@@ -60,11 +60,20 @@ void strbuf_attach_chr(struct strbuf *buff, char ch);
 /**
  * Attach a formatted string to the strbuf.
  *
- * The formatted string is constructed using snprintf(), potentially requiring
- * everal passes to allocate a buffer sufficiently large to hold the formatting
+ * The formatted string is constructed using vsnprintf(), potentially requiring
+ * several passes to allocate a buffer sufficiently large to hold the formatting
  * string.
  * */
 void strbuf_attach_fmt(struct strbuf *buff, const char *fmt, ...);
+
+/**
+ * Variadic alternative to attaching formatted strings to a strbuf.
+ *
+ * The formatted string is constructed using vsnprintf(), potentially requiring
+ * several passes to allocate a buffer sufficiently large to hold the formatting
+ * string.
+ * */
+void strbuf_attach_vfmt(struct strbuf *buff, const char *fmt, va_list varargs);
 
 /**
  * Trim leading and trailing whitespace from an strbuf, returning the number of

--- a/include/utils.h
+++ b/include/utils.h
@@ -66,17 +66,6 @@ void WARN(const char *fmt, ...);
 void set_exit_routine(NORETURN void (*new_exit_routine)(int status));
 
 /**
- * Determine whether the current working directory is a valid git-chat space.
- *
- * The current working directory is a git-chat space if the following conditions
- * are met:
- * - `.git-chat` exists and is a directory
- * - `.git` exists and is a directory
- * - `git rev-parse --is-inside-work-tree` returns with a zero exit status
- * */
-int is_inside_git_chat_space();
-
-/**
  * A self-recovering wrapper for read(). If EINTR or EAGAIN is encountered,
  * retries read().
  * */

--- a/include/working-tree.h
+++ b/include/working-tree.h
@@ -15,8 +15,8 @@
 int is_inside_git_chat_space();
 
 /**
- * If the cwd is a git-chat space, get the absolute path to the local GPG
- * home directory, typically localted under .git/.gnupg.
+ * Get the absolute path to the local GPG home directory, typically located
+ * under $cwd/.git/.gnupg.
  *
  * Returns 0 if the path was successfully written to the given buffer, and non-zero
  * if the path could not be obtained for some reason.
@@ -24,11 +24,28 @@ int is_inside_git_chat_space();
 int get_gpg_homedir(struct strbuf *path);
 
 /**
- * If the cwd is a git-chat space, get the absolute path to the .keys directory.
+ * Get the absolute path to the .keys directory, located under $cwd/.git-chat directory.
  *
  * Returns 0 if the path was successfully written to the given buffer, and non-zero
  * if the path could not be obtained for some reason.
  * */
 int get_keys_dir(struct strbuf *path);
+
+/**
+ * Get the absolute path to the .git-chat directory, located under $cwd directory.
+ *
+ * Returns 0 if the path was successfully written to the given buffer, and non-zero
+ * if the path could not be obtained for some reason.
+ * */
+int get_git_chat_dir(struct strbuf *path);
+
+/**
+ * Get the absolute path to the .chat-cache directory, located under $cwd/.git
+ * directory.
+ *
+ * Returns 0 if the path was successfully written to the given buffer, and non-zero
+ * if the path could not be obtained for some reason.
+ * */
+int get_chat_cache_dir(struct strbuf *path);
 
 #endif //GIT_CHAT_WORKING_TREE_H

--- a/include/working-tree.h
+++ b/include/working-tree.h
@@ -1,0 +1,34 @@
+#ifndef GIT_CHAT_WORKING_TREE_H
+#define GIT_CHAT_WORKING_TREE_H
+
+#include "strbuf.h"
+
+/**
+ * Determine whether the current working directory is a valid git-chat space.
+ *
+ * The current working directory is a git-chat space if the following conditions
+ * are met:
+ * - `.git-chat` exists and is a directory
+ * - `.git` exists and is a directory
+ * - `git rev-parse --is-inside-work-tree` returns with a zero exit status
+ * */
+int is_inside_git_chat_space();
+
+/**
+ * If the cwd is a git-chat space, get the absolute path to the local GPG
+ * home directory, typically localted under .git/.gnupg.
+ *
+ * Returns 0 if the path was successfully written to the given buffer, and non-zero
+ * if the path could not be obtained for some reason.
+ * */
+int get_gpg_homedir(struct strbuf *path);
+
+/**
+ * If the cwd is a git-chat space, get the absolute path to the .keys directory.
+ *
+ * Returns 0 if the path was successfully written to the given buffer, and non-zero
+ * if the path could not be obtained for some reason.
+ * */
+int get_keys_dir(struct strbuf *path);
+
+#endif //GIT_CHAT_WORKING_TREE_H

--- a/src/builtin/config.c
+++ b/src/builtin/config.c
@@ -4,6 +4,7 @@
 #include "parse-config.h"
 #include "config-defaults.h"
 #include "run-command.h"
+#include "working-tree.h"
 #include "fs-utils.h"
 #include "utils.h"
 

--- a/src/builtin/init.c
+++ b/src/builtin/init.c
@@ -6,6 +6,7 @@
 #include <sys/stat.h>
 
 #include "run-command.h"
+#include "working-tree.h"
 #include "parse-options.h"
 #include "parse-config.h"
 #include "fs-utils.h"

--- a/src/fs-utils.c
+++ b/src/fs-utils.c
@@ -228,3 +228,10 @@ int is_executable(const char *name)
 
 	return not_executable ? 0 : st.st_mode & S_IXUSR;
 }
+
+void set_cloexec(int fd)
+{
+	int flags = fcntl(fd, F_GETFD);
+	if (flags < 0 || fcntl(fd, F_SETFD, flags | FD_CLOEXEC) < 0)
+		FATAL("fcntl() failed unexpectedly.");
+}

--- a/src/paging.c
+++ b/src/paging.c
@@ -1,0 +1,167 @@
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+
+#include "paging.h"
+#include "run-command.h"
+#include "fs-utils.h"
+#include "utils.h"
+
+static struct child_process_def cmd;
+
+static int get_pager(struct strbuf *);
+static void register_sigchld_handler(void (*handler)(int));
+static void sigchld_handler(int);
+
+void pager_start()
+{
+	if (!isatty(STDOUT_FILENO))
+		DIE("output stream is not a TTY; cannot display paged content");
+	if (!isatty(STDERR_FILENO))
+		WARN("error stream is not a TTY; content might not be displayed correctly");
+
+	struct strbuf pager_executable;
+	strbuf_init(&pager_executable);
+
+	if (get_pager(&pager_executable))
+		FATAL("unable to display paged output; no pager executable could be found.");
+
+	child_process_def_init(&cmd);
+	str_array_push(&cmd.env, "LESS=FRX", "LV=-c", "MORE=FRX", NULL);
+	cmd.executable = pager_executable.buff;
+
+	child_process_def_stdin(&cmd, STDIN_PROVISIONED);
+	if (pipe(cmd.in_fd) < 0)
+		FATAL("pipe() failed unexpectedly.");
+
+	register_sigchld_handler(sigchld_handler);
+
+	start_command(&cmd);
+	cmd.executable = NULL;
+
+	if (dup2(cmd.in_fd[1], STDOUT_FILENO) < 0)
+		FATAL("dup2() failed unexpectedly.");
+	if (dup2(cmd.in_fd[1], STDERR_FILENO) < 0)
+		FATAL("dup2() failed unexpectedly.");
+
+	close(cmd.in_fd[0]);
+
+	strbuf_release(&pager_executable);
+}
+
+void pager_stop()
+{
+	register_sigchld_handler(SIG_DFL);
+
+	close(STDOUT_FILENO);
+	close(STDERR_FILENO);
+	close(cmd.in_fd[1]);
+
+	finish_command(&cmd);
+	child_process_def_release(&cmd);
+
+	int stdin_fd = open("/proc/self/fd/1", O_WRONLY);
+	if (stdin_fd < 0)
+		FATAL("unable to open /proc/self/fd/1");
+	if (dup2(stdin_fd, STDOUT_FILENO) < 0)
+		FATAL("dup2() failed unexpectedly.");
+
+	int stdout_fd = open("/proc/self/fd/2", O_WRONLY);
+	if (stdout_fd < 0)
+		FATAL("unable to open /proc/self/fd/2");
+	if (dup2(stdout_fd, STDERR_FILENO) < 0)
+		FATAL("dup2() failed unexpectedly.");
+}
+
+/**
+ * Try to locate an executable pager on the system, and place the name of the
+ * executable into the pager strbuf if found.
+ *
+ * The pager that will be used is chosen in the following order:
+ * - GIT_CHAT_PAGER environment variable
+ * - GIT_PAGER environment variable
+ * - PAGER environment variable
+ * - less
+ * - more
+ * - cat
+ *
+ * If a pager cannot be found or is not executable, falls back to the next one
+ * in the list. Returns zero if a suitable pager was found, otherwise returns 1.
+ * */
+static int get_pager(struct strbuf *pager)
+{
+	const char *env = NULL;
+	const char * const recognized_vars[] = {"GIT_CHAT_PAGER", "GIT_PAGER", "PAGER", NULL};
+	for (size_t i = 0; recognized_vars[i]; i++) {
+		env = getenv(*recognized_vars);
+		if (env && *env) {
+			strbuf_attach_str(pager, env);
+			env = recognized_vars[i];
+			break;
+		}
+	}
+
+	if (pager->len && !is_executable(pager->buff)) {
+		WARN("%s defined through %s environment variable is not executable;"
+			 "falling back to another pager", pager->buff, env);
+		strbuf_clear(pager);
+	} else if (pager->len) {
+		return 0;
+	}
+
+	char *pager_path = find_in_path("less");
+	if (pager_path) {
+		strbuf_attach_str(pager, pager_path);
+		free(pager_path);
+		return 0;
+	}
+
+	pager_path = find_in_path("more");
+	if (pager_path) {
+		strbuf_attach_str(pager, pager_path);
+		free(pager_path);
+		return 0;
+	}
+
+	pager_path = find_in_path("cat");
+	if (pager_path) {
+		strbuf_attach_str(pager, pager_path);
+		free(pager_path);
+		return 0;
+	}
+
+	return 1;
+}
+
+/**
+ * SIGCHLD handler used to exit git-chat if the pager child process terminates.
+ * */
+static void sigchld_handler(int sig)
+{
+	(void)sig;
+	int status;
+
+	pid_t ret = waitpid(cmd.pid, &status, WNOHANG);
+	if (ret < 0)
+		FATAL("waitpid() failed unexpectedly.");
+	if (ret != cmd.pid)
+		return;
+
+	close(cmd.in_fd[1]);
+	exit(status);
+}
+
+/**
+ * Register a handler for the SIGCHLD signal.
+ * */
+static void register_sigchld_handler(void (*handler)(int))
+{
+	struct sigaction sa;
+
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = handler;
+
+	sigaction(SIGCHLD, &sa, NULL);
+}

--- a/src/parse-options.c
+++ b/src/parse-options.c
@@ -299,34 +299,46 @@ void show_options(const struct command_option opts[], int err)
 		}
 
 		printed_chars += fprintf(fp, "    ");
-		if (opt.type == OPTION_BOOL_T) {
-			if (opt.s_flag)
-				printed_chars += fprintf(fp, "-%c", opt.s_flag);
+		switch(opt.type) {
+			case OPTION_BOOL_T:
+				if (opt.s_flag)
+					printed_chars += fprintf(fp, "-%c", opt.s_flag);
 
-			if (opt.s_flag && opt.l_flag)
-				printed_chars += fprintf(fp, ", --%s", opt.l_flag);
-			else if (opt.l_flag)
-				printed_chars += fprintf(fp, "--%s", opt.l_flag);
-		} else if (opt.type == OPTION_INT_T) {
-			if (opt.s_flag)
-				printed_chars += fprintf(fp, "-%c=<n>", opt.s_flag);
+				if (opt.s_flag && opt.l_flag)
+					printed_chars += fprintf(fp, ", --%s", opt.l_flag);
+				else if (opt.l_flag)
+					printed_chars += fprintf(fp, "--%s", opt.l_flag);
+				break;
+			case OPTION_INT_T:
+				if (opt.s_flag)
+					printed_chars += fprintf(fp, "-%c=<n>", opt.s_flag);
 
-			if (opt.s_flag && opt.l_flag)
-				printed_chars += fprintf(fp, ", --%s=<n>", opt.l_flag);
-			else if (opt.l_flag)
-				printed_chars += fprintf(fp, "--%s=<n>", opt.l_flag);
-		} else if (opt.type == OPTION_STRING_T) {
-			if (opt.s_flag)
-				printed_chars += fprintf(fp, "-%c", opt.s_flag);
+				if (opt.s_flag && opt.l_flag)
+					printed_chars += fprintf(fp, ", --%s=<n>", opt.l_flag);
+				else if (opt.l_flag)
+					printed_chars += fprintf(fp, "--%s=<n>", opt.l_flag);
+				break;
+			case OPTION_STRING_T:
+				/* fall through */
+			case OPTION_STRING_LIST_T:
+				if (opt.s_flag)
+					printed_chars += fprintf(fp, "-%c", opt.s_flag);
 
-			if (opt.s_flag && opt.l_flag)
-				printed_chars += fprintf(fp, ", --%s", opt.l_flag);
-			else if (opt.l_flag)
-				printed_chars += fprintf(fp, "--%s", opt.l_flag);
+				if (opt.s_flag && opt.l_flag)
+					printed_chars += fprintf(fp, ", --%s", opt.l_flag);
+				else if (opt.l_flag)
+					printed_chars += fprintf(fp, "--%s", opt.l_flag);
 
-			printed_chars += fprintf(fp, " <%s>", opt.str_name);
-		} else if (opt.type == OPTION_COMMAND_T) {
-			printed_chars += fprintf(fp, "%s", opt.str_name);
+				printed_chars += fprintf(fp, " <%s>", opt.str_name);
+				break;
+			case OPTION_COMMAND_T:
+				printed_chars += fprintf(fp, "%s", opt.str_name);
+				break;
+			case OPTION_GROUP_T:
+			case OPTION_END:
+				break;
+			default:
+				BUG("unknown enum for option type");
 		}
 
 		if (printed_chars >= (USAGE_OPTIONS_WIDTH - USAGE_OPTIONS_GAP))

--- a/src/run-command.c
+++ b/src/run-command.c
@@ -16,7 +16,6 @@
 
 extern char **environ;
 
-static inline void set_cloexec(int fd);
 static void merge_env(struct str_array *deltaenv, struct str_array *result);
 static NORETURN void child_exit_routine(int status);
 
@@ -294,19 +293,6 @@ int finish_command(struct child_process_def *cmd)
 	cmd->pid = -1;
 
 	return child_ret_status;
-}
-
-/**
- * Configure the given file descriptor with the FD_CLOEXEC, the close-on-exec,
- * flag, which ensures the file descriptor will automatically be closed after
- * a successful execve(2). If the execve(2) fails, the file descriptor is left
- * open. If left unset, the file descriptor will remain open across an execve(2).
- * */
-static inline void set_cloexec(int fd)
-{
-	int flags = fcntl(fd, F_GETFD);
-	if (flags < 0 || fcntl(fd, F_SETFD, flags | FD_CLOEXEC) < 0)
-		FATAL("fcntl() failed unexpectedly.");
 }
 
 /**

--- a/src/str-array.c
+++ b/src/str-array.c
@@ -5,9 +5,6 @@
 
 #define BUFF_SLOP 8
 
-static void **str_array_detach_internal(struct str_array *str_a, size_t *len, int data);
-
-
 void str_array_init(struct str_array *str_a)
 {
 	*str_a = (struct str_array){ NULL, 0, 0, 0 };
@@ -153,6 +150,16 @@ void str_array_sort(struct str_array *str_a)
 		  entry_comparator);
 }
 
+void str_array_reverse(struct str_array *str_a)
+{
+	struct str_array_entry tmp;
+	for (size_t i = 0; i < (str_a->len / 2); i++) {
+		tmp = str_a->entries[i];
+		str_a->entries[i] = str_a->entries[str_a->len - 1 - i];
+		str_a->entries[str_a->len - 1 - i] = tmp;
+	}
+}
+
 char *str_array_remove(struct str_array *str_a, size_t pos)
 {
 	if (pos >= str_a->len)
@@ -183,6 +190,8 @@ void str_array_clear(struct str_array *str_a)
 
 	str_a->len = 0;
 }
+
+static void **str_array_detach_internal(struct str_array *, size_t *, int);
 
 char **str_array_detach(struct str_array *str_a, size_t *len)
 {

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -64,10 +64,20 @@ void strbuf_attach_chr(struct strbuf *buff, char chr)
 
 void strbuf_attach_fmt(struct strbuf *buff, const char *fmt, ...)
 {
+	va_list varargs;
+	va_start(varargs, fmt);
+
+	strbuf_attach_vfmt(buff, fmt, varargs);
+
+	va_end(varargs);
+}
+
+void strbuf_attach_vfmt(struct strbuf *buff, const char *fmt, va_list varargs)
+{
 	struct strbuf tmp;
 	strbuf_init(&tmp);
 
-	va_list varargs;
+	va_list varargs_cpy;
 
 	size_t size = strlen(fmt);
 	size = size > 64 ? size : 64;
@@ -76,12 +86,12 @@ void strbuf_attach_fmt(struct strbuf *buff, const char *fmt, ...)
 		ssize_t len;
 		strbuf_grow(&tmp, size);
 
-		va_start(varargs, fmt);
-		len = vsnprintf(tmp.buff, size, fmt, varargs);
+		va_copy(varargs_cpy, varargs);
+		len = vsnprintf(tmp.buff, size, fmt, varargs_cpy);
 		if (len < 0)
 			FATAL("Unexpected error from vsnprintf()");
 
-		va_end(varargs);
+		va_end(varargs_cpy);
 
 		if (len < size) {
 			tmp.len = len;

--- a/src/working-tree.c
+++ b/src/working-tree.c
@@ -1,0 +1,80 @@
+#include <string.h>
+#include <errno.h>
+#include <sys/stat.h>
+
+#include "working-tree.h"
+#include "run-command.h"
+#include "fs-utils.h"
+#include "utils.h"
+
+int is_inside_git_chat_space()
+{
+	int errsv = errno;
+
+	struct stat sb;
+	if (stat(".git-chat", &sb) == -1 || !S_ISDIR(sb.st_mode)) {
+		LOG_DEBUG("Cannot stat .git-chat directory; %s", strerror(errno));
+		errno = errsv;
+		return 0;
+	}
+
+	if (stat(".git", &sb) == -1 || !S_ISDIR(sb.st_mode)) {
+		LOG_DEBUG("Cannot stat .git directory; %s", strerror(errno));
+		errno = errsv;
+		return 0;
+	}
+
+	struct child_process_def cmd;
+	child_process_def_init(&cmd);
+	cmd.git_cmd = 1;
+	cmd.std_fd_info = STDIN_NULL | STDOUT_NULL | STDERR_NULL;
+	argv_array_push(&cmd.args, "rev-parse", "--is-inside-work-tree", NULL);
+
+	//if 'git rev-parse --is-inside-work-tree' return with a zero exit status,
+	//its safe enough to assume we are in a git-chat space.
+	int status = run_command(&cmd);
+	child_process_def_release(&cmd);
+
+	errno = errsv;
+	return status == 0;
+}
+
+int get_gpg_homedir(struct strbuf *path)
+{
+	if (path->len)
+		BUG("buffer passed to get_gpg_homedir() must be empty");
+
+	if (!is_inside_git_chat_space())
+		return 1;
+
+	struct strbuf cwd_buff;
+	strbuf_init(&cwd_buff);
+	if (get_cwd(&cwd_buff)) {
+		strbuf_release(&cwd_buff);
+		return 1;
+	}
+
+	strbuf_attach_fmt(path, "%s/.git/.gnupg", cwd_buff.buff);
+	strbuf_release(&cwd_buff);
+	return 0;
+}
+
+int get_keys_dir(struct strbuf *path)
+{
+	if (path->len)
+		BUG("buffer passed to get_keys_dir() must be empty");
+
+	if (!is_inside_git_chat_space())
+		return 1;
+
+	struct strbuf cwd_buff;
+	strbuf_init(&cwd_buff);
+	if (get_cwd(&cwd_buff)) {
+		strbuf_release(&cwd_buff);
+		return 1;
+	}
+
+	strbuf_attach_fmt(path, "%s/.keys", cwd_buff.buff);
+	strbuf_release(&cwd_buff);
+	return 0;
+}

--- a/test/integration-runner.sh
+++ b/test/integration-runner.sh
@@ -1,62 +1,71 @@
 #!/usr/bin/env bash
-#
-# Integration test runner for all integration tests.
-#
-# Options:
-#	--from-dir <directory>
-#		By default, tests are executed from 'trash/' directory relative to this
-#		script. This command is used to override this.
-#
-#	--git-chat-installed <path>
-#		If git-chat is installed in an alternate directory, use that installation
-#		rather than the global one. Simply places the given directory at the
-#		beginning of the PATH.
-#
-#	--test <pattern>
-#		Run specific tests according to a given pattern.
-#
-#	--valgrind
-#		Run all git-chat binaries under valgrind memcheck. Note that this will
-#		take much longer to execute.
-#
-#	-v, --verbose
-#		Be more verbose. Prints the output from the test setup and test commands
-#		executed.
-#
-#	-d, --debug
-#		Print very verbose debugging information. This will set -x on each
-#		integration test, and will set the GIT_CHAT_LOG_LEVEL to TRACE. This
-#		is particularly useful when debugging strange behavior in failing tests.
-#
-#	--no-color
-#		Don't print colored output.
-#
-#
-# Environment:
-#	TEST_TRASH_DIR
-#		Equivalent to using --from-dir <directory> option.
-#
-#	TEST_GIT_CHAT_INSTALLED
-#		Equivalent to using --git-chat-installed <path> option.
-#
-#	TEST_PATTERN
-#		Equivalent to using --test <pattern> option.
-#
-#	TEST_VALGRIND
-#		Equivalent to using --valgrind
-#
-#	VALGRIND_TOOL_OPTIONS
-#		Pass options to valgrind memcheck. This will override any default options.
-#
-#	TEST_VERBOSE
-#		Equivalent to using --verbose option.
-#
-#	TEST_DEBUG
-#		Equivalent to using --debug option.
-#
-#	TEST_NO_COLOR_OUT
-#		Equivalent to using -- option.
-#
+
+function show_help () {
+	cat <<EOS
+This script is the integration test runner for all integration tests.
+
+usage: integration-runner.sh [options]
+
+Options:
+	--from-dir <directory>
+		By default, tests are executed from 'trash/' directory relative to this
+		script. This command is used to override this.
+
+	--git-chat-installed <path>
+		If git-chat is installed in an alternate directory, use that installation
+		rather than the global one. Simply places the given directory at the
+		beginning of the PATH.
+
+	--test <pattern>
+		Run specific tests according to a given pattern.
+
+	--valgrind
+		Run all git-chat binaries under valgrind memcheck. Note that this will
+		take much longer to execute.
+
+	-v, --verbose
+		Be more verbose. Prints the output from the test setup and test commands
+		executed.
+
+	-h, --help
+		Display usage information and exit.
+
+	-d, --debug
+		Print very verbose debugging information. This will set -x on each
+		integration test, and will set the GIT_CHAT_LOG_LEVEL to TRACE. This
+		is particularly useful when debugging strange behavior in failing tests.
+
+	--no-color
+		Don't print colored output.
+
+
+Environment:
+	TEST_TRASH_DIR
+		Equivalent to using --from-dir <directory> option.
+
+	TEST_GIT_CHAT_INSTALLED
+		Equivalent to using --git-chat-installed <path> option.
+
+	TEST_PATTERN
+		Equivalent to using --test <pattern> option.
+
+	TEST_VALGRIND
+		Equivalent to using --valgrind
+
+	VALGRIND_TOOL_OPTIONS
+		Pass options to valgrind memcheck. This will override any default options.
+
+	TEST_VERBOSE
+		Equivalent to using --verbose option.
+
+	TEST_DEBUG
+		Equivalent to using --debug option.
+
+	TEST_NO_COLOR_OUT
+		Equivalent to using --no-color option.
+
+EOS
+}
 
 TEST_RUNNER_PATH="$( cd "$(dirname "${0}")" ; pwd -P )"
 TEST_PATTERN="${TEST_PATTERN:-t[0-9][0-9][0-9]*.sh}"
@@ -85,6 +94,10 @@ while [[ ${#} -gt 0 ]]; do
 		-v|--verbose)
 			TEST_VERBOSE=1
 			shift
+			;;
+		-h|--help)
+			show_help
+			exit 0
 			;;
 		-d|--debug)
 			TEST_DEBUG=1

--- a/test/integration/t003-git-chat-init.sh
+++ b/test/integration/t003-git-chat-init.sh
@@ -28,19 +28,19 @@ assert_success 'git chat init should initialize empty git repository' '
 	grep "Successfully initialized git-chat space." out
 '
 
-assert_success 'reinitializing a git-chat space should not overwrite .git-chat or .keys directory' '
+assert_success 'reinitializing a git-chat space should not overwrite .git-chat' '
 	reset_trash_dir
 ' '
 	git chat init &&
+	cp $TEST_RESOURCES_DIR/gpgkeys/*.pub.gpg .git-chat/keys &&
 	echo "my space" >>.git-chat/description &&
-	echo "my keys" >.keys/key.gpg &&
-	shasum .git-chat/* >expected_git_chat &&
-	shasum .keys/* >expected_keys &&
+	shasum .git-chat/description >expected_git_chat_description &&
+	shasum .git-chat/keys/* >expected_git_chat_keys &&
 	! git chat init &&
-	shasum .git-chat/* >actual_git_chat &&
-	shasum .keys/* >actual_keys &&
-	cmp -s expected_git_chat actual_git_chat &&
-	cmp -s expected_keys actual_keys
+	shasum .git-chat/description >actual_git_chat_description &&
+	shasum .git-chat/keys/* >actual_git_chat_keys &&
+	cmp -s expected_git_chat_description actual_git_chat_description &&
+	cmp -s expected_git_chat_keys actual_git_chat_keys
 '
 
 assert_success 'git chat init -q should not print to stdout' '
@@ -67,7 +67,7 @@ assert_success 'git chat init should create the expected directory structure' '
 	[ -d ".git" ] &&
 	[ -d ".git/chat-cache" ] &&
 	[ -d ".git-chat" ] &&
-	[ -d ".keys" ] &&
+	[ -d ".git-chat/keys" ] &&
 	[ -f ".git-chat/config" ] &&
 	[ -f ".git-chat/description" ]
 '

--- a/test/integration/t004-git-chat-message.sh
+++ b/test/integration/t004-git-chat-message.sh
@@ -14,16 +14,17 @@ assert_success 'git chat message without any recipients or keys should fail' '
 	reset_trash_dir &&
 	git chat init &&
 	setup_test_gpg &&
-	[ -z "$(ls -A .keys/)" ]
+	[ -z "$(ls -A .git-chat/keys)" ]
 ' '
 	! git chat message -m "hello world" 2>err &&
 	grep "no message recipients" err
 '
 
 assert_success 'git chat message with unknown recipient should fail' '
-	cp $TEST_RESOURCES_DIR/gpgkeys/*.pub.gpg .keys &&
+	cp $TEST_RESOURCES_DIR/gpgkeys/*.pub.gpg .git-chat/keys &&
 	setup_test_gpg
 ' '
+	git chat message -m "hello world" --recipient alice.jones@example.com &&
 	! git chat message -m "hello world" --recipient unknown@unknown.ca 2>err &&
 	grep "one or more message recipients have no public gpg key available" err
 '
@@ -33,7 +34,7 @@ assert_success 'author of encrypted message should not be able to decrypt messag
 ' '
 	git chat message -m "hello world" --recipient alice.jones@example.com &&
 	git show -s --format="%B" HEAD >commit_msg &&
-	! gpg2 --no-default-keyring --keyring "$(pwd)/.git/chat-cache/keyring.gpg" \
+	! gpg2 --no-default-keyring --keyring "$(pwd)/.git/.gnupg/keyring.gpg" \
 		--batch --passphrase password --decrypt commit_msg 2>err
 	grep "No secret key" err
 '

--- a/test/unit/str-array-test.c
+++ b/test/unit/str-array-test.c
@@ -393,6 +393,72 @@ TEST_DEFINE(str_array_sort_test)
 	TEST_END();
 }
 
+TEST_DEFINE(str_array_reverse_empty)
+{
+	struct str_array str_a;
+	str_array_init(&str_a);
+
+	TEST_START() {
+		// no need to assert much here; valgrind should pick up any memory weirdness
+		str_array_sort(&str_a);
+		assert_null(str_a.entries);
+		assert_zero(str_a.len);
+	}
+
+	str_array_release(&str_a);
+	TEST_END();
+}
+
+TEST_DEFINE(str_array_reverse_odd)
+{
+	struct str_array str_a;
+	str_array_init(&str_a);
+
+	TEST_START() {
+		str_array_push(&str_a, "1", NULL);
+		str_array_reverse(&str_a);
+		assert_string_eq("1", str_array_get(&str_a, 0));
+
+		str_array_clear(&str_a);
+
+		str_array_push(&str_a, "1", "2", "3", "4", "5", NULL);
+		str_array_reverse(&str_a);
+		assert_string_eq("5", str_array_get(&str_a, 0));
+		assert_string_eq("4", str_array_get(&str_a, 1));
+		assert_string_eq("3", str_array_get(&str_a, 2));
+		assert_string_eq("2", str_array_get(&str_a, 3));
+		assert_string_eq("1", str_array_get(&str_a, 4));
+	}
+
+	str_array_release(&str_a);
+	TEST_END();
+}
+
+TEST_DEFINE(str_array_reverse_even)
+{
+	struct str_array str_a;
+	str_array_init(&str_a);
+
+	TEST_START() {
+		str_array_push(&str_a, "1", "2", NULL);
+		str_array_reverse(&str_a);
+		assert_string_eq("2", str_array_get(&str_a, 0));
+		assert_string_eq("1", str_array_get(&str_a, 1));
+
+		str_array_clear(&str_a);
+
+		str_array_push(&str_a, "1", "2", "3", "4", NULL);
+		str_array_reverse(&str_a);
+		assert_string_eq("4", str_array_get(&str_a, 0));
+		assert_string_eq("3", str_array_get(&str_a, 1));
+		assert_string_eq("2", str_array_get(&str_a, 2));
+		assert_string_eq("1", str_array_get(&str_a, 3));
+	}
+
+	str_array_release(&str_a);
+	TEST_END();
+}
+
 TEST_DEFINE(str_array_remove_test)
 {
 	struct str_array str_a;
@@ -538,6 +604,9 @@ int str_array_test(struct test_runner_instance *instance)
 			{ "inserting element in str-array should shift elements correctly", str_array_insert_test },
 			{ "inserting element in str-array should insert without duplication", str_array_insert_nodup_test },
 			{ "sorting element in str-array should sort by strcmp() order", str_array_sort_test },
+			{ "reversing an str-array with no elements should do nothing", str_array_reverse_empty },
+			{ "reversing an str-array with an odd number of elements should reverse correctly", str_array_reverse_odd },
+			{ "reversing an str-array with an even number of elements should reverse correctly", str_array_reverse_even },
 			{ "removing element from str-array should shift elements correctly", str_array_remove_test },
 			{ "detaching strings from str-array should correctly detach", str_array_detach_test },
 			{ "detaching data from str-array should correctly detach data", str_array_detach_data_test },

--- a/test/unit/strbuf-test.c
+++ b/test/unit/strbuf-test.c
@@ -131,9 +131,9 @@ TEST_DEFINE(strbuf_attach_fmt_test)
 
 		char string[128];
 		memset(string, 'A', 128);
-		string[127] = 0;
 		string[0] = '%';
 		string[1] = 's';
+		string[127] = 0;
 
 		strbuf_attach_fmt(&buf, string, "HITHERE");
 		assert_eq(132, buf.len);


### PR DESCRIPTION
## Improvements to Integration Test Runner
The integration test runner now accepts -h|--help which displays usage
information.

## Improvements to git-chat-init
Various refactors and improvements to make the code more maintainable.

## Fixes and Improvements to Paging API
The paging_stop function did not correctly restore stdout and stderr
streams. This was corrected.

Also introduced a pager_kill() function that will terminate the child
process. Useful when an exceptional state is encountered.

## Various Refactors and Improvements
- Created "working-tree" for utilities related to git-chat spaces
- Improvements to gpg-interface
- Moved around some utilities

## Create str_array_reverse() Function
Created a function that can be used to reverse the entries in an
str-array. Also created integration tests to cover this functionality.

## parse-options bug fix
The parse-options API did not correctly display usage information for
the OPTION_STRING_LIST_T option type. This has been corrected.

## Improvements to utils
The BUG/WARN/DIE/FATAL functions were updated to prefix each line with
the prefix (warn:, fatal:, etc.) rather than just the first line.

## Implemented a Simple API for Paging Output
Created a new utility that can be used to display paged output through a
paging application (like less, more, or in dire cases, cat) configured
by the user.

## run-command fixes
The run-command start_command() function had a bug that prevented
arguments from being passed to /bin/sh when the use_shell flag was
enabled. This has been corrected.

## Improvements to strbuf API
Added a new strbuf_attach_vfmt() function that accepts a va_list. This
is particularly useful for any function that wants to format a string
with arguments passed through a va_list.

