### PR TITLE
strbuf: performance improvement to strbuf_attach_fmt

### DIFF
--- a/test/unit/strbuf-test.c
+++ b/test/unit/strbuf-test.c
@@ -119,6 +119,10 @@ TEST_DEFINE(strbuf_attach_fmt_test)
 		assert_string_eq("Hello World 1", buf.buff);
 		assert_true(is_null_terminated(&buf));
 
+		strbuf_attach_fmt(&buf, "%s %s %d", "Hello", "World", 1);
+		assert_string_eq("Hello World 1Hello World 1", buf.buff);
+		assert_true(is_null_terminated(&buf));
+
 		strbuf_release(&buf);
 		strbuf_init(&buf);
 


### PR DESCRIPTION
Reworked strbuf_attach_fmt such that vsnprintf only needs to be invoked
twice--once to obtain the length of the buffer, and once to write to the
buffer.