### PR TITLE
parse-options: support hidden options

### DIFF
--- a/include/parse-options.h
+++ b/include/parse-options.h
@@ -5,13 +5,14 @@
 #include <stdarg.h>
 
 enum opt_type {
-	OPTION_BOOL_T,
-	OPTION_INT_T,
-	OPTION_STRING_T,
-	OPTION_STRING_LIST_T,
-	OPTION_COMMAND_T,
-	OPTION_GROUP_T,
-	OPTION_END
+	OPTION_BOOL_T = (1 << 0),
+	OPTION_INT_T = (1 << 1),
+	OPTION_STRING_T = (1 << 2),
+	OPTION_STRING_LIST_T = (1 << 3),
+	OPTION_COMMAND_T = (1 << 4),
+	OPTION_GROUP_T = (1 << 5),
+	OPTION_HIDDEN_T = (1 << 6),
+	OPTION_END = (1 << 6)
 };
 
 struct command_option;
@@ -20,8 +21,8 @@ struct command_option {
 	const char *l_flag;
 	const char *str_name;
 	const char *desc;
-	enum opt_type type;
 	void *arg_value;
+	enum opt_type type;
 };
 
 struct usage_string;
@@ -29,22 +30,38 @@ struct usage_string {
 	const char *usage_desc;
 };
 
-#define OPT_SHORT_BOOL(S,D,V)			{ (S), NULL,  NULL, (D), OPTION_BOOL_T, (V) }
-#define OPT_SHORT_INT(S,D,V)			{ (S), NULL,  NULL, (D), OPTION_INT_T, (V) }
-#define OPT_SHORT_STRING(S,N,D,V)		{ (S), NULL,  (N), (D), OPTION_STRING_T, (V) }
-#define OPT_SHORT_STRING_LIST(S,N,D,V)		{ (S), NULL,  (N), (D), OPTION_STRING_LIST_T, (V) }
-#define OPT_LONG_BOOL(L,D,V)			{ 0, (L),  NULL, (D), OPTION_BOOL_T, (V) }
-#define OPT_LONG_INT(L,D,V)				{ 0, (L),  NULL, (D), OPTION_INT_T, (V) }
-#define OPT_LONG_STRING(L,N,D,V)		{ 0, (L),  (N), (D), OPTION_STRING_T, (V) }
-#define OPT_LONG_STRING_LIST(L,N,D,V)		{ 0, (L),  (N), (D), OPTION_STRING_LIST_T, (V) }
-#define OPT_BOOL(S,L,D,V)				{ (S), (L), NULL, (D), OPTION_BOOL_T, (V) }
-#define OPT_INT(S,L,D,V)				{ (S), (L), NULL, (D), OPTION_INT_T, (V) }
-#define OPT_STRING(S,L,N,D,V)			{ (S), (L), (N), (D), OPTION_STRING_T, (V) }
-#define OPT_STRING_LIST(S,L,N,D,V)			{ (S), (L), (N), (D), OPTION_STRING_LIST_T, (V) }
-#define OPT_CMD(N,D,V)					{ 0, NULL, (N), (D), OPTION_COMMAND_T, (V) }
-#define OPT_GROUP(N)					{ 0, NULL, NULL, N, OPTION_GROUP_T, NULL }
-#define OPT_END()						{ 0, NULL, NULL, NULL, OPTION_END, NULL }
-
+#define OPT_HIDDEN(S,L,V,T) \
+		{ (S), (L), NULL, NULL, (V), OPTION_HIDDEN_T | (T) }
+#define OPT_SHORT_BOOL(S,D,V) \
+		{ (S), NULL, NULL, (D), (V), OPTION_BOOL_T }
+#define OPT_SHORT_INT(S,D,V) \
+		{ (S), NULL, NULL, (D), (V), OPTION_INT_T }
+#define OPT_SHORT_STRING(S,N,D,V) \
+		{ (S), NULL, (N), (D), (V), OPTION_STRING_T }
+#define OPT_SHORT_STRING_LIST(S,N,D,V) \
+		{ (S), NULL, (N), (D), (V), OPTION_STRING_LIST_T }
+#define OPT_LONG_BOOL(L,D,V) \
+		{ 0, (L), NULL, (D), (V), OPTION_BOOL_T }
+#define OPT_LONG_INT(L,D,V) \
+		{ 0, (L), NULL, (D), (V), OPTION_INT_T }
+#define OPT_LONG_STRING(L,N,D,V) \
+		{ 0, (L), (N), (D), (V), OPTION_STRING_T }
+#define OPT_LONG_STRING_LIST(L,N,D,V) \
+		{ 0, (L), (N), (D), (V), OPTION_STRING_LIST_T }
+#define OPT_BOOL(S,L,D,V) \
+		{ (S), (L), NULL, (D), (V), OPTION_BOOL_T }
+#define OPT_INT(S,L,D,V) \
+		{ (S), (L), NULL, (D), (V), OPTION_INT_T }
+#define OPT_STRING(S,L,N,D,V) \
+		{ (S), (L), (N), (D), (V), OPTION_STRING_T }
+#define OPT_STRING_LIST(S,L,N,D,V) \
+		{ (S), (L), (N), (D), (V), OPTION_STRING_LIST_T }
+#define OPT_CMD(N,D,V) \
+		{ 0, NULL, (N), (D), (V), OPTION_COMMAND_T }
+#define OPT_GROUP(N) \
+		{ 0, NULL, NULL, (N), NULL, OPTION_GROUP_T }
+#define OPT_END() \
+		{ 0, NULL, NULL, NULL, NULL, OPTION_END }
 #define USAGE(DESC)					{ (DESC) }
 #define USAGE_END()					{ NULL }
 

--- a/src/parse-options.c
+++ b/src/parse-options.c
@@ -9,11 +9,215 @@
 #define USAGE_OPTIONS_WIDTH		24
 #define USAGE_OPTIONS_GAP		2
 
+/**
+ * Shift `count` elements from `argv`, starting at position `arg_index`.
+ * `len` is read for the length of `argv`, to guard against overflow.
+ *
+ * Returns the new length of `argv`.
+ * */
+static int array_shift(char *argv[], int arg_index, int len, int count)
+{
+	if (len <= 0 || arg_index >= len)
+		return len;
 
-static int parse_long_option(int, char *[], int, const struct command_option[]);
-static int parse_short_option(int, char *[], int, const struct command_option[]);
-static int parse_subcommand(char *[], int, const struct command_option[]);
-static inline void array_shift(char *[], int, int *, int);
+	// guard against removing too many elements from argv
+	if (count > (len - arg_index))
+		BUG("attempted to remove more elements from argv than available");
+
+	int new_len = len - count;
+	for (int index = arg_index; index < new_len; index++)
+		argv[index] = argv[index + count];
+
+	argv[new_len] = NULL;
+	return new_len;
+}
+
+static int parse_long_option(int argc, char *argv[], int arg_index,
+		const struct command_option options[])
+{
+	// skip '--' prefix
+	char *arg = argv[arg_index] + 2;
+	int new_len = argc;
+
+	for (const struct command_option *op = options; !(op->type & OPTION_END); op++) {
+		if (!op->l_flag)
+			continue;
+
+		// if the argument is a boolean arg, set value to one and return
+		if (op->type & OPTION_BOOL_T && !strcmp(arg, op->l_flag)) {
+			new_len = array_shift(argv, arg_index, new_len, 1);
+			*(int *) op->arg_value = 1;
+			break;
+		}
+
+		/*
+		 * Check to see if this argument matches the flag, taking into account
+		 * that the argument might be suffixed with =<value>.
+		 * */
+		size_t flag_len = strlen(op->l_flag);
+		if (!op->l_flag || strncmp(arg, op->l_flag, flag_len) != 0)
+			continue;
+
+		if (strlen(arg) == flag_len) {
+			// check that argument value is in the next argument
+			if (arg_index + 1 >= argc)
+				continue;
+
+			arg = argv[arg_index + 1];
+
+			if (op->type & OPTION_INT_T) {
+				char *tailptr = NULL;
+				long arg_value = strtol(arg, &tailptr, 0);
+
+				// verify that integer was parsed successfully
+				if (tailptr == (arg + strlen(arg))) {
+					new_len = array_shift(argv, arg_index, new_len, 2);
+					*(long *) op->arg_value = arg_value;
+					break;
+				}
+			} else if (op->type & OPTION_STRING_T) {
+				new_len = array_shift(argv, arg_index, new_len, 2);
+
+				*(char **) op->arg_value = (void *) arg;
+				break;
+			} else if (op->type & OPTION_STRING_LIST_T) {
+				new_len = array_shift(argv, arg_index, new_len, 2);
+
+				str_array_push(op->arg_value, arg, NULL);
+				break;
+			}
+		} else if (strlen(arg) > flag_len && arg[flag_len] == '=') {
+			// argument value is attached to the argument with '='
+			arg = arg + flag_len + 1;
+
+			if (op->type & OPTION_INT_T) {
+				char *tailptr = NULL;
+				long arg_value = strtol(arg, &tailptr, 0);
+
+				// verify that integer was parsed successfully
+				if (tailptr == (arg + strlen(arg))) {
+					new_len = array_shift(argv, arg_index, new_len, 1);
+					*(long *) op->arg_value = arg_value;
+					break;
+				}
+			} else if (op->type & OPTION_STRING_T) {
+				new_len = array_shift(argv, arg_index, new_len, 1);
+
+				*(char **) op->arg_value = arg;
+				break;
+			} else if (op->type & OPTION_STRING_LIST_T) {
+				new_len = array_shift(argv, arg_index, new_len, 1);
+
+				str_array_push(op->arg_value, arg, NULL);
+				break;
+			}
+		}
+	}
+
+	return argc - new_len;
+}
+
+static int parse_short_option(int argc, char *argv[], int arg_index,
+		const struct command_option options[])
+{
+	int new_len = argc;
+
+	// skip '-' prefix
+	for (char *arg = argv[arg_index] + 1; *arg; arg++) {
+		for (const struct command_option *op = options; !(op->type & OPTION_END); op++) {
+			if (!op->s_flag || op->s_flag != *arg) {
+				// if the option is undefined, stop
+				const struct command_option *next = op + 1;
+				if (next->type & OPTION_END)
+					return argc - new_len;
+
+				continue;
+			}
+
+			if (op->type & OPTION_BOOL_T) {
+				*(int *) op->arg_value = 1;
+				break;
+			}
+
+			if (op->type & (OPTION_STRING_T |OPTION_STRING_LIST_T)) {
+				// intermediate options that accept values are disallowed
+				if (*(arg + 1))
+					return argc - new_len;
+
+				// if no value given
+				if (arg_index + 1 >= argc)
+					return argc - new_len;
+			}
+
+			if (op->type & OPTION_INT_T) {
+				char *tailptr = NULL;
+				long arg_value = 0;
+
+				if (*(arg + 1)) {
+					// if integer follows flag (e.g. '-c9', '-d101')
+					arg = arg + 1;
+					arg_value = strtol(arg, &tailptr, 0);
+
+					// verify that integer was parsed successfully
+					if (tailptr == (arg + strlen(arg))) {
+						new_len = array_shift(argv, arg_index, new_len, 1);
+						*(long *) op->arg_value = arg_value;
+					}
+				} else {
+					arg = argv[arg_index + 1];
+					arg_value = strtol(arg, &tailptr, 0);
+
+					// verify that integer was parsed successfully
+					if (tailptr == (arg + strlen(arg))) {
+						new_len = array_shift(argv, arg_index, new_len, 2);
+						*(long *) op->arg_value = arg_value;
+					}
+				}
+
+				return argc - new_len;
+			}
+
+			if (op->type & OPTION_STRING_T) {
+				arg = argv[arg_index + 1];
+				new_len = array_shift(argv, arg_index, new_len, 2);
+
+				*(char **) op->arg_value = arg;
+				return argc - new_len;
+			}
+
+			if (op->type & OPTION_STRING_LIST_T) {
+				arg = argv[arg_index + 1];
+				new_len = array_shift(argv, arg_index, new_len, 2);
+
+				str_array_push(op->arg_value, arg, NULL);
+				return argc - new_len;
+			}
+		}
+	}
+
+	new_len = array_shift(argv, arg_index, new_len, 1);
+	return argc - new_len;
+}
+
+static int parse_subcommand(char *argv[], int arg_index,
+		const struct command_option options[])
+{
+	for (const struct command_option *op = options; !(op->type & OPTION_END); op++) {
+		if (!(op->type & OPTION_COMMAND_T))
+			continue;
+
+		char *arg = argv[arg_index];
+		if (!strcmp(arg, op->str_name)) {
+			if (op->arg_value) {
+				*(int *) op->arg_value = 1;
+			}
+
+			return 1;
+		}
+	}
+
+	return 0;
+}
 
 int parse_options(int argc, char *argv[], const struct command_option options[],
 		int skip_first, int stop_on_unknown)
@@ -24,7 +228,7 @@ int parse_options(int argc, char *argv[], const struct command_option options[],
 
 	// shift to remove first argument, typically name of program
 	if (skip_first)
-		array_shift(argv, 0, &new_len, 1);
+		new_len = array_shift(argv, 0, new_len, 1);
 
 	int arg_index = 0;
 	while (arg_index < new_len) {
@@ -32,12 +236,16 @@ int parse_options(int argc, char *argv[], const struct command_option options[],
 
 		// if argument is equal to `--`, stop processing
 		if (!strcmp(arg, "--")) {
-			array_shift(argv, arg_index, &new_len, 1);
+			new_len = array_shift(argv, arg_index, new_len, 1);
 			return new_len;
 		}
 
 		int shifted_args = 0;
-		if (!strncmp(arg, "--", 2)) {
+		if (!*arg) {
+			// if an empty arg is provided, skip it unless instructed to stop on unknown
+			if (!stop_on_unknown)
+				shifted_args = new_len - array_shift(argv, arg_index, new_len, 1);
+		} else if (!strncmp(arg, "--", 2)) {
 			// if argument is prefixed with `--`, it is a long argument
 			shifted_args = parse_long_option(new_len, argv, arg_index, options);
 		} else if (arg[0] == '-') {
@@ -58,193 +266,6 @@ int parse_options(int argc, char *argv[], const struct command_option options[],
 	}
 
 	return new_len;
-}
-
-static int parse_long_option(int argc, char *argv[], int arg_index,
-		const struct command_option options[])
-{
-	// skip '--' prefix
-	char *arg = argv[arg_index] + 2;
-	int new_len = argc;
-
-	for (const struct command_option *op = options; op->type != OPTION_END; op++) {
-		if (!op->l_flag)
-			continue;
-
-		// if the argument is a boolean arg, set value to one and return
-		if (op->type == OPTION_BOOL_T && !strcmp(arg, op->l_flag)) {
-			array_shift(argv, arg_index, &new_len, 1);
-			*(int *) op->arg_value = 1;
-			break;
-		}
-
-		/*
-		 * Check to see if this argument matches the flag, taking into account
-		 * that the argument might be suffixed with =<value>.
-		 * */
-		size_t flag_len = strlen(op->l_flag);
-		if (!op->l_flag || strncmp(arg, op->l_flag, flag_len) != 0)
-			continue;
-
-		if (strlen(arg) == flag_len) {
-			// check that argument value is in the next argument
-			if (arg_index + 1 >= argc)
-				continue;
-
-			arg = argv[arg_index + 1];
-
-			if (op->type == OPTION_INT_T) {
-				char *tailptr = NULL;
-				long arg_value = strtol(arg, &tailptr, 0);
-
-				// verify that integer was parsed successfully
-				if (tailptr == (arg + strlen(arg))) {
-					array_shift(argv, arg_index, &new_len, 2);
-					*(long *) op->arg_value = arg_value;
-					break;
-				}
-			} else if (op->type == OPTION_STRING_T) {
-				array_shift(argv, arg_index, &new_len, 2);
-
-				*(char **) op->arg_value = arg;
-				break;
-			} else if (op->type == OPTION_STRING_LIST_T) {
-				array_shift(argv, arg_index, &new_len, 2);
-
-				str_array_push(op->arg_value, arg, NULL);
-				break;
-			}
-		} else if (strlen(arg) > flag_len && arg[flag_len] == '=') {
-			// argument value is attached to the argument with '='
-			arg = arg + flag_len + 1;
-
-			if (op->type == OPTION_INT_T) {
-				char *tailptr = NULL;
-				long arg_value = strtol(arg, &tailptr, 0);
-
-				// verify that integer was parsed successfully
-				if (tailptr == (arg + strlen(arg))) {
-					array_shift(argv, arg_index, &new_len, 1);
-					*(long *) op->arg_value = arg_value;
-					break;
-				}
-			} else if (op->type == OPTION_STRING_T) {
-				array_shift(argv, arg_index, &new_len, 1);
-
-				*(char **) op->arg_value = arg;
-				break;
-			} else if (op->type == OPTION_STRING_LIST_T) {
-				array_shift(argv, arg_index, &new_len, 1);
-
-				str_array_push(op->arg_value, arg, NULL);
-				break;
-			}
-		}
-	}
-
-	return argc - new_len;
-}
-
-static int parse_short_option(int argc, char *argv[], int arg_index,
-		const struct command_option options[])
-{
-	int new_len = argc;
-
-	// skip '-' prefix
-	for (char *arg = argv[arg_index] + 1; *arg; arg++) {
-		for (const struct command_option *op = options; op->type != OPTION_END; op++) {
-			if (!op->s_flag || op->s_flag != *arg) {
-				// if the option is undefined, stop
-				const struct command_option *next = op + 1;
-				if (next->type == OPTION_END)
-					return argc - new_len;
-
-				continue;
-			}
-
-			if (op->type == OPTION_BOOL_T) {
-				*(int *) op->arg_value = 1;
-				break;
-			}
-
-			if (op->type == OPTION_STRING_T || op->type == OPTION_STRING_LIST_T) {
-				// intermediate options that accept values are disallowed
-				if (*(arg + 1))
-					return argc - new_len;
-
-				// if no value given
-				if (arg_index + 1 >= argc)
-					return argc - new_len;
-			}
-
-			if (op->type == OPTION_INT_T) {
-				char *tailptr = NULL;
-				long arg_value = 0;
-
-				if (*(arg + 1)) {
-					// if integer follows flag (e.g. '-c9', '-d101')
-					arg = arg + 1;
-					arg_value = strtol(arg, &tailptr, 0);
-
-					// verify that integer was parsed successfully
-					if (tailptr == (arg + strlen(arg))) {
-						array_shift(argv, arg_index, &new_len, 1);
-						*(long *) op->arg_value = arg_value;
-					}
-				} else {
-					arg = argv[arg_index + 1];
-					arg_value = strtol(arg, &tailptr, 0);
-
-					// verify that integer was parsed successfully
-					if (tailptr == (arg + strlen(arg))) {
-						array_shift(argv, arg_index, &new_len, 2);
-						*(long *) op->arg_value = arg_value;
-					}
-				}
-
-				return argc - new_len;
-			}
-
-			if (op->type == OPTION_STRING_T) {
-				arg = argv[arg_index + 1];
-				array_shift(argv, arg_index, &new_len, 2);
-
-				*(char **) op->arg_value = arg;
-				return argc - new_len;
-			}
-
-			if (op->type == OPTION_STRING_LIST_T) {
-				arg = argv[arg_index + 1];
-				array_shift(argv, arg_index, &new_len, 2);
-
-				str_array_push(op->arg_value, arg, NULL);
-				return argc - new_len;
-			}
-		}
-	}
-
-	array_shift(argv, arg_index, &new_len, 1);
-	return argc - new_len;
-}
-
-static int parse_subcommand(char *argv[], int arg_index,
-		const struct command_option options[])
-{
-	for (const struct command_option *op = options; op->type != OPTION_END; op++) {
-		if (op->type != OPTION_COMMAND_T)
-			continue;
-
-		char *arg = argv[arg_index];
-		if (!strcmp(arg, op->str_name)) {
-			if (op->arg_value) {
-				*(int *) op->arg_value = 1;
-			}
-
-			return 1;
-		}
-	}
-
-	return 0;
 }
 
 void show_usage(const struct usage_string cmd_usage[], int err,
@@ -286,11 +307,14 @@ void show_options(const struct command_option opts[], int err)
 	FILE *fp = err ? stderr : stdout;
 
 	size_t index = 0;
-	while (opts[index].type != OPTION_END) {
+	while (!(opts[index].type & OPTION_END)) {
 		struct command_option opt = opts[index++];
 		int printed_chars = 0;
 
-		if (opt.type == OPTION_GROUP_T) {
+		if (opt.type & OPTION_HIDDEN_T)
+			continue;
+
+		if (opt.type & OPTION_GROUP_T) {
 			if (index > 1)
 				fprintf(fp, "\n");
 
@@ -299,46 +323,22 @@ void show_options(const struct command_option opts[], int err)
 		}
 
 		printed_chars += fprintf(fp, "    ");
-		switch(opt.type) {
-			case OPTION_BOOL_T:
-				if (opt.s_flag)
-					printed_chars += fprintf(fp, "-%c", opt.s_flag);
+		if (opt.type & (OPTION_BOOL_T | OPTION_INT_T | OPTION_STRING_T | OPTION_STRING_LIST_T)) {
+			const char *short_fstr = "-%c";
+			const char *long_fstr = "%s--%s";
 
-				if (opt.s_flag && opt.l_flag)
-					printed_chars += fprintf(fp, ", --%s", opt.l_flag);
-				else if (opt.l_flag)
-					printed_chars += fprintf(fp, "--%s", opt.l_flag);
-				break;
-			case OPTION_INT_T:
-				if (opt.s_flag)
-					printed_chars += fprintf(fp, "-%c=<n>", opt.s_flag);
+			if (opt.s_flag)
+				printed_chars += fprintf(fp, short_fstr, opt.s_flag);
+			else if (opt.l_flag)
+				printed_chars += fprintf(fp, long_fstr, opt.s_flag ? ", " : "",
+						opt.l_flag);
 
-				if (opt.s_flag && opt.l_flag)
-					printed_chars += fprintf(fp, ", --%s=<n>", opt.l_flag);
-				else if (opt.l_flag)
-					printed_chars += fprintf(fp, "--%s=<n>", opt.l_flag);
-				break;
-			case OPTION_STRING_T:
-				/* fall through */
-			case OPTION_STRING_LIST_T:
-				if (opt.s_flag)
-					printed_chars += fprintf(fp, "-%c", opt.s_flag);
-
-				if (opt.s_flag && opt.l_flag)
-					printed_chars += fprintf(fp, ", --%s", opt.l_flag);
-				else if (opt.l_flag)
-					printed_chars += fprintf(fp, "--%s", opt.l_flag);
-
-				printed_chars += fprintf(fp, " <%s>", opt.str_name);
-				break;
-			case OPTION_COMMAND_T:
-				printed_chars += fprintf(fp, "%s", opt.str_name);
-				break;
-			case OPTION_GROUP_T:
-			case OPTION_END:
-				break;
-			default:
-				BUG("unknown enum for option type");
+			// if option takes an argument, print it
+			if (!(opt.type & OPTION_BOOL_T))
+				printed_chars += fprintf(fp, " <%s>",
+						opt.type & OPTION_INT_T ? "n" : opt.str_name);
+		} else if (opt.type & OPTION_COMMAND_T) {
+			printed_chars += fprintf(fp, "%s", opt.str_name);
 		}
 
 		if (printed_chars >= (USAGE_OPTIONS_WIDTH - USAGE_OPTIONS_GAP))
@@ -370,17 +370,4 @@ void variadic_show_usage_with_options(const struct usage_string cmd_usage[],
 {
 	variadic_show_usage(cmd_usage, optional_message_format, varargs, err);
 	show_options(opts, err);
-}
-
-static inline void array_shift(char *argv[], int arg_index, int *len, int count)
-{
-	if (*len <= 0 || arg_index >= *len)
-		return;
-
-	int new_len = *len - count;
-	for (int index = arg_index; index < new_len; index++)
-		argv[index] = argv[index + count];
-
-	*len = new_len;
-	argv[new_len] = NULL;
 }

--- a/test/unit/parse-options-test.c
+++ b/test/unit/parse-options-test.c
@@ -521,6 +521,30 @@ TEST_DEFINE(parse_options_combined_short_arg_test)
 	TEST_END();
 }
 
+TEST_DEFINE(parse_options_empty_argument_test)
+{
+	int quiet = 0;
+	char *file = NULL;
+
+	options[1].arg_value = &quiet;
+	options[3].arg_value = &file;
+
+	TEST_START() {
+		const int argc = 5;
+		char *argv[] = {"myprog", "-F", "my file", "", "-q"};
+		int new_argc = parse_options(argc, argv, options, 1, 0);
+		assert_eq_msg(0, new_argc, "parse_options did not skip empty args");
+
+		assert_string_eq_msg("my file", file, "unexpected arg value");
+		assert_true_msg(quiet, "boolean arg not set");
+	}
+
+	options[1].arg_value = NULL;
+	options[3].arg_value = NULL;
+
+	TEST_END();
+}
+
 const char *suite_name = SUITE_NAME;
 int test_suite(struct test_runner_instance *instance)
 {
@@ -541,6 +565,7 @@ int test_suite(struct test_runner_instance *instance)
 			{ "parse_options with skip_first enabled should ignore first argument in arg vector", parse_options_skip_first_arg_test },
 			{ "parse_options with stop_on_unknown enabled should stop if unknown arg found in arg vector", parse_options_unknown_arg_test },
 			{ "combined short options should parse correctly", parse_options_combined_short_arg_test },
+			{ "providing an empty string to parse-options should simply ignore the arg", parse_options_empty_argument_test },
 			{ NULL, NULL }
 	};
 


### PR DESCRIPTION
Some convenience options don't need to be shown to the user in standard
usage strings. Add a new macro to support hidden options.

A few minor improvements were made to this area as well.