### PR TITLE
git-chat-read improvements

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -105,20 +105,20 @@ usage: git chat message [(--recipient <alias>)...] (-m | --message) <message>
 ```
 
 ### git chat publish
-**IN PROGRESS** Push a any new messages to the remote repository.
+This feature is not implemented. Messages can be published with `git push`. Consider creating a `git chat publish` alias.
 
 ### git chat read
 Read messages in the current channel.
 
 ```
-usage: git chat read [<commit hash>]
+usage: git chat read  [(-n | --max-count) <n>] [--no-color] [<commit hash>]
    or: git chat read (-h | --help)
 
     -h, --help          show usage and exit
 ```
 
 ### git chat get
-**IN PROGRESS** Fetch any new messages from the remote repository.
+This feature is not implemented. Messages can be fetched with `git pull --ff-only`. Consider creating a `git chat get` alias.
 
 ### git chat config
 ```

--- a/docs/git-chat-read.1
+++ b/docs/git-chat-read.1
@@ -7,7 +7,7 @@ git-chat-read \- decrypt and show messages
 .SH SYNOPSIS
 .sp
 .nf
-\fIgit-chat-read\fR [<commit hash>]
+\fIgit-chat-read\fR [(-n | --max-count) <n>] [--no-color] [<commit hash>]
 \fIgit-chat-read\fR (\-h | \-\-help)
 
 
@@ -35,6 +35,14 @@ When a commit hash is provided, only that message is shown.
 
 
 .SH OPTIONS
+.TP
+\-n, \-\-max\-count
+Limit the number of messages shown.
+
+.TP
+\-\-no\-color
+Suppress ANSI color escape sequences from output. Defaults to true when output is a TTY.
+
 .TP
 \-h, \-\-help
 Print a simple synopsis and exit.

--- a/include/paging.h
+++ b/include/paging.h
@@ -28,11 +28,14 @@
  * If any of those pagers are not available (i.e. cannot be found, or not executable),
  * then git-chat will default to "less", "more", or in dire cases, "cat".
  *
+ * When starting the pager, the caller can provide additional options to
+ * configure the pager.
+ *
  * paging usage:
  *
  * int main(void) {
  *     // initializes the pager
- *     pager_start();
+ *     pager_start(GIT_CHAT_PAGER_DEFAULT);
  *
  *     printf("large string... is paged");
  *     fprintf(stderr, "this is also paged");
@@ -45,11 +48,50 @@
  * */
 
 /**
+ * Clear screen and paint from top down. Equivalent to the '-c' option
+ * recognized by `less` and `more`.
+ */
+#define GIT_CHAT_PAGER_CLR_SCRN (1 << 0)
+
+/**
+ * Exit if the entire contents can be written to the first terminal screen.
+ * Equivalent to the '-F' option recognized by `less` and `more`.
+ */
+#define GIT_CHAT_PAGER_EXIT_FULL_WRITE (1 << 1)
+
+/**
+ * Output raw ANSI color escape sequences in raw form. Equivalent to the '-R'
+ * option recognized by `less` and `more`.
+ */
+#define GIT_CHAT_PAGER_RAW_CTRL_CHR (1 << 2)
+
+/**
+ * Disable termcap initialization. Equivalent to the '-X' option recognized by
+ * `less` and `more`.
+ */
+#define GIT_CHAT_PAGER_NO_TERMCAP_INIT (1 << 3)
+
+/**
+ * Common pager options. Equivalent to the following:
+ * - GIT_CHAT_PAGER_EXIT_FULL_WRITE
+ * - GIT_CHAT_PAGER_RAW_CTRL_CHR
+ * - GIT_CHAT_PAGER_NO_TERMCAP_INIT
+ */
+#define GIT_CHAT_PAGER_DEFAULT (\
+		GIT_CHAT_PAGER_EXIT_FULL_WRITE | \
+		GIT_CHAT_PAGER_RAW_CTRL_CHR | \
+		GIT_CHAT_PAGER_NO_TERMCAP_INIT)
+
+/**
  * Initialize the pager.
  *
- * Standard output stream must by a TTY. If the underlying paging application
+ * The caller can provide bit-wise OR'ed options, which can manipulate the
+ * behaviour of the pager (if the underlying pager supports such features).
+ *
+ * Standard output stream must by a TTY. If the output stream is not a TTY,
+ * this function simply returns. If the underlying paging application
  * terminates, git-chat will also exit.
  * */
-void pager_start(void);
+void pager_start(int pager_opts);
 
 #endif //GIT_CHAT_PAGING_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -14,6 +14,14 @@
 #define FILE_WRITE_FAILED "failed to write to file '%s'"
 
 /**
+ * Frequently used macro constants should be defined here.
+ * */
+#define ANSI_COLOR_RED     "\x1b[31m"
+#define ANSI_COLOR_GREEN   "\x1b[32m"
+#define ANSI_COLOR_CYAN    "\x1b[36m"
+#define ANSI_COLOR_RESET   "\x1b[0m"
+
+/**
  * Simple assertion function. Invoking this function will print a message to
  * stderr, and exit with status EXIT_FAILURE.
  *

--- a/src/builtin/channel-list.c
+++ b/src/builtin/channel-list.c
@@ -14,10 +14,6 @@
 #include "utils.h"
 #include "working-tree.h"
 
-#define ANSI_COLOR_RED     "\x1b[31m"
-#define ANSI_COLOR_GREEN   "\x1b[32m"
-#define ANSI_COLOR_RESET   "\x1b[0m"
-
 static const struct usage_string channel_cmd_usage[] = {
 		USAGE("git chat channel list [(-a | --all)]"),
 		USAGE_END()
@@ -586,7 +582,7 @@ int channel_list(int argc, char *argv[])
 	struct table_dimensions dims;
 	calculate_table_dimensions(&channel_refs, &dims);
 
-	pager_start();
+	pager_start(GIT_CHAT_PAGER_DEFAULT);
 
 	// print local channels
 	printf("local channels\n");

--- a/src/parse-options.c
+++ b/src/parse-options.c
@@ -100,7 +100,7 @@ static int parse_long_option(int argc, char *argv[], int arg_index,
 				// verify that integer was parsed successfully
 				if (tailptr == (arg + strlen(arg))) {
 					array_shift(argv, arg_index, &new_len, 2);
-					*(long *) op->arg_value = arg_value;
+					*(int *) op->arg_value = (int) arg_value;
 					break;
 				}
 			} else if (op->type == OPTION_STRING_T) {
@@ -125,7 +125,7 @@ static int parse_long_option(int argc, char *argv[], int arg_index,
 				// verify that integer was parsed successfully
 				if (tailptr == (arg + strlen(arg))) {
 					array_shift(argv, arg_index, &new_len, 1);
-					*(long *) op->arg_value = arg_value;
+					*(int *) op->arg_value = (int) arg_value;
 					break;
 				}
 			} else if (op->type == OPTION_STRING_T) {
@@ -189,7 +189,7 @@ static int parse_short_option(int argc, char *argv[], int arg_index,
 					// verify that integer was parsed successfully
 					if (tailptr == (arg + strlen(arg))) {
 						array_shift(argv, arg_index, &new_len, 1);
-						*(long *) op->arg_value = arg_value;
+						*(int *) op->arg_value = (int) arg_value;
 					}
 				} else {
 					arg = argv[arg_index + 1];
@@ -198,7 +198,7 @@ static int parse_short_option(int argc, char *argv[], int arg_index,
 					// verify that integer was parsed successfully
 					if (tailptr == (arg + strlen(arg))) {
 						array_shift(argv, arg_index, &new_len, 2);
-						*(long *) op->arg_value = arg_value;
+						*(int *) op->arg_value = (int) arg_value;
 					}
 				}
 

--- a/test/integration/t007-git-chat-read.sh
+++ b/test/integration/t007-git-chat-read.sh
@@ -63,3 +63,38 @@ assert_success 'git chat read should print ciphertext when cannot be decrypted' 
 	grep -v "hello world" out &&
 	grep "message could not be decrypted" out
 '
+
+assert_success 'git chat read with message limit should print no more than that number of messages' '
+	reset_trash_dir &&
+	setup_test_gpg &&
+	git chat init &&
+	git chat import-key -f "$TEST_RESOURCES_DIR/gpgkeys/test_user.pub.gpg"
+' '
+	git chat message -m "hello world 1" &&
+	git chat message -m "hello world 2" &&
+	PAGER=/usr/bin/cat git chat --passphrase password read --max-count 1 >out &&
+	grep "hello world 2" out &&
+	grep -v "hello world 1" out
+'
+
+assert_success 'git chat read with message limit less than zero should print all messages' '
+	setup_test_gpg
+' '
+	PAGER=/usr/bin/cat git chat --passphrase password read --max-count -1 >out &&
+	grep "hello world 1" out &&
+	grep "hello world 2" out
+'
+
+assert_success 'git chat read should print colored headers when output is a tty' '
+	setup_test_gpg
+' '
+	GIT_CHAT_PAGER=/usr/bin/cat script -qec "git chat --passphrase password read --max-count 1" out &&
+	grep -P "\033\[32m\[.*DEC.*\]\033\[0m" out
+'
+
+assert_success 'git chat read should print colored headers when output is a tty' '
+	setup_test_gpg
+' '
+	GIT_CHAT_PAGER=/usr/bin/cat git chat --passphrase password read --max-count 1 >out &&
+	grep -v -P "\033\[32m\[.*DEC.*\]\033\[0m" out
+'

--- a/test/unit/git-commit-parse-test.c
+++ b/test/unit/git-commit-parse-test.c
@@ -6,8 +6,6 @@
 #define HEADER_PREFIX_PARENT "parent "
 #define HEADER_PREFIX_AUTHOR "author "
 #define HEADER_PREFIX_COMMITTER "committer "
-#define HEADER_PREFIX_CUSTOM_1 "userdef1 "
-#define HEADER_PREFIX_CUSTOM_2 "userdef2 "
 
 #define OID_VALID "e4854A7f9bca6ac1bcaee3f1e8587f6953d542c0"
 #define SIGNATURE_NAME "Brandon Richardson"

--- a/test/unit/parse-config-test.c
+++ b/test/unit/parse-config-test.c
@@ -25,7 +25,7 @@ static int write_conf_to_fd(const char data[], size_t len)
 static int read_fd_to_strbuf(int fd, struct strbuf *buff)
 {
 	char tmp[1024];
-	ssize_t bytes_read = 0;
+	ssize_t bytes_read;
 	while ((bytes_read = xread(fd, tmp, 1024)) > 0)
 		strbuf_attach(buff, tmp, bytes_read);
 

--- a/test/unit/parse-options-test.c
+++ b/test/unit/parse-options-test.c
@@ -83,10 +83,10 @@ TEST_DEFINE(parse_options_short_bool_test)
 TEST_DEFINE(parse_options_short_int_test)
 {
 	int bool_val_1 = 0;
-	long int_val_1 = 0;
-	long int_val_2 = 0;
-	long int_val_3 = 0;
-	long int_val_4 = 0;
+	int int_val_1 = 0;
+	int int_val_2 = 0;
+	int int_val_3 = 0;
+	int int_val_4 = 0;
 	options[1].arg_value = &bool_val_1;
 	options[38].arg_value = &int_val_1;
 	options[48].arg_value = &int_val_2;
@@ -211,8 +211,8 @@ TEST_DEFINE(parse_options_long_bool_test)
 
 TEST_DEFINE(parse_options_long_int_test)
 {
-	long int_val_1 = 0;
-	long int_val_2 = 0;
+	int int_val_1 = 0;
+	int int_val_2 = 0;
 	options[37].arg_value = &int_val_1;
 	options[39].arg_value = &int_val_2;
 
@@ -320,8 +320,8 @@ TEST_DEFINE(parse_options_bool_test)
 TEST_DEFINE(parse_options_int_test)
 {
 	int bool_val_1 = 0;
-	long int_val_1 = 0;
-	long int_val_2 = 0;
+	int int_val_1 = 0;
+	int int_val_2 = 0;
 	options[1].arg_value = &bool_val_1;
 	options[22].arg_value = &int_val_1;
 	options[40].arg_value = &int_val_2;

--- a/test/unit/str-array-test.c
+++ b/test/unit/str-array-test.c
@@ -226,7 +226,7 @@ TEST_DEFINE(str_array_push_test)
 {
 	struct str_array str_a;
 	str_array_init(&str_a);
-	int ret = 0;
+	int ret;
 
 	TEST_START() {
 		ret = str_array_push(&str_a, NULL);
@@ -268,7 +268,7 @@ int str_array_vpush_test_helper(size_t args, ...)
 {
 	struct str_array str_a;
 	str_array_init(&str_a);
-	int ret = 0;
+	int ret ;
 
 	TEST_START() {
 		va_list ap;

--- a/test/unit/strbuf-test.c
+++ b/test/unit/strbuf-test.c
@@ -152,7 +152,7 @@ TEST_DEFINE(strbuf_trim_test) {
 	struct strbuf buf;
 	strbuf_init(&buf);
 
-	int ret = 0;
+	int ret;
 	TEST_START() {
 		//entirely whitespace
 		char *str = "  \t    \r\v  \n \f";


### PR DESCRIPTION
Fixes #73 
Fixes #74
Fixes #71 

A few improvements were made to git-chat-read under this revision to
improve user experience. Message headings in the output is now shown in
color, unless the --no-color option is provided. The --max-count option
was added to limit the number of messages shown. The semantics of the
pager was improved for easier reading.