### PR TITLE
git-chat-message: add --reply and --compose

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -91,7 +91,8 @@ usage: git chat channel create [(-n | --name) <alias>] [(-d | --description) <de
 Create a new message in the current channel. The message is encrypted with GPG. The message is not yet published, and needs to be pushed to the remote repository using `git chat publish`.
 
 ```
-usage: git chat message [(--recipient <alias>)...] (-m | --message) <message>
+usage: git chat message [(--recipient <alias>)...] [(--reply | --compose <n>)]
+   or: git chat message [(--recipient <alias>)...] (-m | --message) <message>
    or: git chat message [(--recipient <alias>)...] (-f | --file) <filename>
    or: git chat message (-h | --help)
 
@@ -101,7 +102,10 @@ usage: git chat message [(--recipient <alias>)...] (-m | --message) <message>
                         provide the message contents
     -f, --file <filename>
                         read message contents from file
+    --reply             show the last message when composing new messages
+    --compose=<n>       show last messages when composing new messages
     -h, --help          show usage and exit
+
 ```
 
 ### git chat publish

--- a/docs/git-chat-config.1
+++ b/docs/git-chat-config.1
@@ -1,7 +1,7 @@
 .TH git-chat-config 1 "@CMAKE_COMPILATION_DATE@" "git-chat @CMAKE_PROJECT_VERSION_MAJOR@.@CMAKE_PROJECT_VERSION_MINOR@.@CMAKE_PROJECT_VERSION_PATCH@" "git-chat manual"
 
 .SH NAME
-git-chat-config \- Configure the current channel
+git-chat-config \- configure the current channel
 
 .SH SYNOPSIS
 .sp

--- a/docs/git-chat-message.1
+++ b/docs/git-chat-message.1
@@ -1,11 +1,12 @@
 .TH git-chat-message 1 "@CMAKE_COMPILATION_DATE@" "git-chat @CMAKE_PROJECT_VERSION_MAJOR@.@CMAKE_PROJECT_VERSION_MINOR@.@CMAKE_PROJECT_VERSION_PATCH@" "git-chat manual"
 
 .SH NAME
-git-chat-message \- Encrypt plaintext messages and commit them to the git history
+git-chat-message \- encrypt plaintext messages and commit them to the git history
 
 .SH SYNOPSIS
 .sp
 .nf
+\fIgit-chat-message\fR [(\-\-recipient <alias>)...] [(--reply | --compose <n>)]
 \fIgit-chat-message\fR [(\-\-recipient <alias>)...] (\-m | \-\-message) <message>
 \fIgit-chat-message\fR [(\-\-recipient <alias>)...] (\-f | \-\-file) <filename>
 \fIgit-chat-message\fR (\-h | \-\-help)
@@ -14,7 +15,7 @@ git-chat-message \- Encrypt plaintext messages and commit them to the git histor
 .SH DESCRIPTION
 \fIgit-chat\fR supports asymmetric encryption of plaintext messages through \fBGNU Privacy Guard\fR (gpg).
 
-New messages are created as empty commit objects in the Git database. If successful, new message commits are created on the tip of the current branch. You can manually decrypt messages by piping the commit message body into gpg:
+New messages are created as empty commit objects in the Git database. If successful, new message commits are created on the tip of the current channel. You can manually decrypt messages by piping the commit message body into gpg:
 
 .PP
 .in +4n
@@ -58,6 +59,10 @@ Provide the message at the command line.
 .TP
 \-f, \-\-file <file>
 Provide the message as the content of a file. Use \fI-\fR to read the message from the standard input.
+
+.TP
+\-\-reply, \-\-compose <n>
+When composing new messages in the editor, decrypt and show the last <n> messages from the current channel in a horizontal split window. \fI\-\-reply\fR is an alias to \fI\-\-compose=1\fR.
 
 .TP
 \-h, \-\-help

--- a/docs/git-chat-read.1
+++ b/docs/git-chat-read.1
@@ -22,12 +22,19 @@ When a commit hash is provided, only that message is shown.
 .in +4n
 .EX
 [Sat Oct 17 22:23:29 2020 DEC Brandon Richardson]
+
 	this is the most recent message
+
 [Sat Oct 17 22:23:15 2020 DEC Brandon Richardson]
+
 	this is an example message
+
 [Sat Oct 17 21:27:14 2020 PLN Brandon Richardson]
+
 	brandon.richardson@siemens.com joined the channel.
+
 [Sat Oct 17 21:27:14 2020 PLN Brandon Richardson]
+
 	You have reached the beginning of time.
 .EE
 .in

--- a/include/git/commit.h
+++ b/include/git/commit.h
@@ -33,6 +33,12 @@ struct git_commit {
 	struct strbuf body;
 };
 
+enum message_type {
+	PLAINTEXT,
+	DECRYPTED,
+	UNKNOWN_ERROR
+};
+
 /**
  * Allocate memory and initialize members of a commit object to their defaults.
  * */
@@ -68,5 +74,27 @@ int git_commit_index_with_options(const char *commit_message, ...);
  * */
 int commit_parse(struct git_commit *commit, const char commit_id[GIT_HEX_OBJECT_ID],
 		const char *data, size_t len);
+
+/**
+ * Pretty-print a single message and write to the file descriptor `output_fd`.
+ *
+ * `commit` is the raw commit, as read from `commit_parse()`.
+ *
+ * `message` represents a raw or externally-decrypted message. `message_type`
+ * is used to indicate the format of the message, either:
+ * - plain text message,
+ * - decrypted message, or
+ * - the raw message when decryption fails unexpectedly.
+ *
+ * `no_color` is used to control whether raw ANSI color control sequences are
+ * written to the output.
+ *
+ * Messages are displayed in the following format:
+ * [<timestamp> <ENC | PLN> <author>]
+ *   <message>...
+ *   <message>...
+ * */
+void pretty_print_message(struct git_commit *commit, struct strbuf *message,
+		enum message_type type, int no_color, int output_fd);
 
 #endif //GIT_CHAT_COMMIT_H

--- a/include/git/graph-traversal.h
+++ b/include/git/graph-traversal.h
@@ -1,0 +1,24 @@
+#ifndef GIT_CHAT_INCLUDE_GIT_GRAPH_TRAVERSAL_H
+#define GIT_CHAT_INCLUDE_GIT_GRAPH_TRAVERSAL_H
+
+#include "git/commit.h"
+
+typedef int (*graph_traversal_cb)(struct git_commit *commit, void *data);
+
+/**
+ * Traverse the git commit graph in reverse chronological order, starting at
+ * `commit` (which can be a reference or a commit hash) and reading up to
+ * `limit` commits. Commit objects are parsed and passed to the callback
+ * function `cb`, along with an arbitrary pointer `data`.
+ *
+ * When `commit` is null, traversal starts from the current commit (HEAD).
+ * If `limit` is negative, traverse all commits.
+ *
+ * Returns zero if the traversal successful, return non-negative if the
+ * graph traversal callback returned non-zero, and return negative if an error
+ * occurred.
+ */
+int traverse_commit_graph(const char *commit, int limit, graph_traversal_cb cb,
+		void *data);
+
+#endif //GIT_CHAT_INCLUDE_GIT_GRAPH_TRAVERSAL_H

--- a/include/strbuf.h
+++ b/include/strbuf.h
@@ -76,6 +76,11 @@ void strbuf_attach_fmt(struct strbuf *buff, const char *fmt, ...);
 void strbuf_attach_vfmt(struct strbuf *buff, const char *fmt, va_list varargs);
 
 /**
+ * Read and attach data from an open file descriptor to a strbuf.
+ * */
+void strbuf_attach_fd(struct strbuf *buff, int fd);
+
+/**
  * Trim leading and trailing whitespace from an strbuf, returning the number of
  * characters removed from the buffer.
  *

--- a/include/utils.h
+++ b/include/utils.h
@@ -65,6 +65,13 @@ NORETURN void DIE(const char *fmt, ...);
 void WARN(const char *fmt, ...);
 
 /**
+ * Function used to inform the user.
+ *
+ * The message is printed to stderr.
+ * */
+void INFO(const char *fmt, ...);
+
+/**
  * Configure which routine should be invoked to exit the current process.
  *
  * By default, exit(int) is used as the exit routine. However, this cannot be

--- a/src/builtin/message.c
+++ b/src/builtin/message.c
@@ -5,6 +5,7 @@
 
 #include "str-array.h"
 #include "run-command.h"
+#include "git/graph-traversal.h"
 #include "gnupg/gpg-common.h"
 #include "working-tree.h"
 #include "fs-utils.h"
@@ -14,121 +15,245 @@
 #define BUFF_LEN 1024
 
 static const struct usage_string message_cmd_usage[] = {
+		USAGE("git chat message [(--recipient <alias>)...] [(--reply | --compose <n>)]"),
 		USAGE("git chat message [(--recipient <alias>)...] (-m | --message) <message>"),
 		USAGE("git chat message [(--recipient <alias>)...] (-f | --file) <filename>"),
 		USAGE("git chat message (-h | --help)"),
 		USAGE_END()
 };
 
-static int create_message(struct str_array *, const char *, const char *);
-static int encrypt_message_asym(struct gc_gpgme_ctx *, struct str_array *,
-		struct strbuf *, struct strbuf *);
-static void compose_message(struct strbuf *);
-static void read_message_from_file(const char *, struct strbuf *);
-static int filter_gpg_keylist_by_recipients(struct _gpgme_key *, void *);
-static int write_commit(struct strbuf *);
+struct graph_traversal_context {
+	int message_fd;
+	struct gc_gpgme_ctx *gpg_ctx;
+};
 
-
-int cmd_message(int argc, char *argv[])
+/**
+ * Launch vim to edit the file `compose_file`, optionally opening the file
+ * `ro_info_pane_file` in a separate read-only window for informational messages.
+ *
+ * Returns the exit status of vim.
+ * */
+static int launch_editor(const char *compose_file, const char *ro_info_pane_file)
 {
-	int show_help = 0;
-	struct str_array recipients;
-	const char *message = NULL;
-	const char *file = NULL;
+	struct strbuf info_panel_op, compose_panel_op;
+	struct child_process_def cmd;
+	int ret;
 
-	const struct command_option message_cmd_options[] = {
-			OPT_LONG_STRING_LIST("recipient", "alias", "specify one or more recipients that may read the message", &recipients),
-			OPT_STRING('m', "message", "message", "provide the message contents", &message),
-			OPT_STRING('f', "file", "filename", "read message contents from file", &file),
-			OPT_BOOL('h', "help", "show usage and exit", &show_help),
-			OPT_END()
-	};
+	strbuf_init(&info_panel_op);
+	strbuf_init(&compose_panel_op);
 
-	str_array_init(&recipients);
-	argc = parse_options(argc, argv, message_cmd_options, 1, 1);
-	if (argc > 0) {
-		show_usage_with_options(message_cmd_usage, message_cmd_options, 1, "error: unknown option '%s'", argv[0]);
-		str_array_release(&recipients);
-		return 1;
+	child_process_def_init(&cmd);
+	cmd.executable = "vim";
+
+	argv_array_push(&cmd.args, "-n", "-c", "set nobackup nowritebackup", NULL);
+
+	// open `ro_info_pane_file` in a read-only split panel
+	if (ro_info_pane_file) {
+		strbuf_attach_fmt(&info_panel_op, "view %s", ro_info_pane_file);
+		strbuf_attach_fmt(&compose_panel_op, "abo sp %s", compose_file);
+
+		argv_array_push(&cmd.args, "-c", info_panel_op.buff, "-c",
+				compose_panel_op.buff, NULL);
+	} else {
+		argv_array_push(&cmd.args, compose_file, NULL);
 	}
 
-	if (show_help) {
-		show_usage_with_options(message_cmd_usage, message_cmd_options, 0, NULL);
-		return 0;
-	}
+	ret = run_command(&cmd);
 
-	if (message && file) {
-		show_usage_with_options(message_cmd_usage, message_cmd_options, 1, "error: mixing --message and --file is not supported");
-		str_array_release(&recipients);
-		return 1;
-	}
+	child_process_def_release(&cmd);
+	strbuf_release(&info_panel_op);
+	strbuf_release(&compose_panel_op);
 
-	int ret = create_message(&recipients, message, file);
-
-	str_array_release(&recipients);
 	return ret;
 }
 
 /**
- * Create a new message with the given recipients.
- *
- * The mutually-exclusive arguments `message` and `file` are used to supply
- * the contents of the message. If both arguments are NULL, the editor
- * is spawned to allow the user to compose the message.
- *
- * If `file` is non-null, the message content is read from a file with the
- * given path, unless the path is `-` which will read the message from stdin.
- *
- * Message cannot be empty.
+ * Create a new file `file` with rw permissions for the current user, or
+ * truncate the file if it already exists.
  * */
-static int create_message(struct str_array *recipients, const char *message,
-		const char *file)
+static void create_truncate_file(const char *file)
 {
-	struct gc_gpgme_ctx ctx;
-	struct strbuf message_buff, ciphertext;
+	int fd = open(file, O_WRONLY | O_TRUNC | O_CREAT, S_IRUSR | S_IWUSR);
+	if (fd < 0)
+		FATAL(FILE_OPEN_FAILED, file);
+	close(fd);
+}
 
-	if (!is_inside_git_chat_space())
-		DIE("Where are you? It doesn't look like you're in the right directory.");
+/**
+ * Callback function invoked by the `graph-traversal` API. Attempts to decrypt
+ * messages from the given `commit` and write a pretty-printed result to
+ * a file descriptor supplied through `data`.
+ *
+ * The void pointer is assumed to be a pointer to a `graph_traversal_context`
+ * structure.
+ *
+ * Returns zero to indicate success.
+ * */
+static int commit_traversal_cb(struct git_commit *commit, void *data)
+{
+	struct graph_traversal_context *ctx = (struct graph_traversal_context *) data;
+	struct gc_gpgme_ctx *gpg_ctx = ctx->gpg_ctx;
+	int fd = ctx->message_fd;
 
-	gpgme_context_init(&ctx, 1);
-	strbuf_init(&message_buff);
+	struct strbuf decrypted_text;
+	strbuf_init(&decrypted_text);
 
-	// build the message into the message_buff buffer
-	if (!message && !file)
-		compose_message(&message_buff);
-	else if (file)
-		read_message_from_file(file, &message_buff);
-	else
-		strbuf_attach_str(&message_buff, message);
+	int ret = decrypt_asymmetric_message(gpg_ctx, &commit->body, &decrypted_text);
+	if (!ret) {
+		// decryption successful
+		pretty_print_message(commit, &decrypted_text, DECRYPTED, 1, fd);
+	} else if (ret > 0) {
+		// commit body is not gpg message; print commit message body
+		pretty_print_message(commit, &commit->body, PLAINTEXT, 1, fd);
+	} else {
+		strbuf_clear(&decrypted_text);
+		strbuf_attach_str(&decrypted_text, "message could not be decrypted.");
+		pretty_print_message(commit, &decrypted_text, UNKNOWN_ERROR, 1, fd);
+	}
 
-	if (!message_buff.len)
-		DIE("message aborted (message was not provided)");
+	strbuf_release(&decrypted_text);
 
-	strbuf_init(&ciphertext);
-	struct strbuf keys_dir_path;
-	strbuf_init(&keys_dir_path);
-	if (get_keys_dir(&keys_dir_path))
-		FATAL(".keys directory does not exist or cannot be used for some reason");
+	return 0;
+}
 
-	// reimport the gpg keys into the keyring
-	rebuild_gpg_keyring(&ctx, keys_dir_path.buff);
-	strbuf_release(&keys_dir_path);
+/**
+ * Prompt the user with a vim editor to compose their message. Upon editing,
+ * the message is attached to the given strbuf `buff`.
+ *
+ * When `compose` is non-zero, that number of messages on the current channel
+ * will be decrypted and shown in the editor.
+ *
+ * When vim is started, the editor will open `.git/GC_EDITMSG` with rw permission
+ * for the current user only. The file is first truncated to zero bytes, then
+ * vim is opened to write to the file. Once vim exits, the file is read into the
+ * given buffer, and then the file is truncated once more.
+ *
+ * Decrypted messages are written to `.git/GC_REPLY_LAST` with rw permission for
+ * the current user only. Once vim exits, this file is truncated.
+ * */
+static void compose_message(struct strbuf *buff, int compose)
+{
+	struct strbuf cwd, compose_file;
 
-	int ret = encrypt_message_asym(&ctx, recipients, &message_buff, &ciphertext);
-	if (ret == 0)
-		DIE("no message recipients; no one will be able to read your message.");
-	if (ret < 0)
-		DIE("one or more message recipients have no public gpg key available.");
+	if (!isatty(STDOUT_FILENO))
+		DIE("cannot launch editor; output is not a terminal");
 
-	gpgme_context_release(&ctx);
+	strbuf_init(&cwd);
+	strbuf_init(&compose_file);
 
-	memset(message_buff.buff, 0, message_buff.alloc);
+	if (get_cwd(&cwd))
+		FATAL("unable to obtain the current working directory from getcwd()");
+	strbuf_attach_fmt(&compose_file, "%s/.git/GC_EDITMSG", cwd.buff);
 
-	if (write_commit(&ciphertext))
-		FATAL("failed to write ciphertext as the commit message body");
+	// create or clear files with correct permissions
+	create_truncate_file(compose_file.buff);
 
-	strbuf_release(&message_buff);
-	strbuf_release(&ciphertext);
+	int ret;
+	if (compose) {
+		struct gc_gpgme_ctx gpg_ctx;
+		gpgme_context_init(&gpg_ctx, 0);
+
+		struct strbuf reply_messages_file;
+		strbuf_init(&reply_messages_file);
+		strbuf_attach_fmt(&reply_messages_file, "%s/.git/GC_REPLY_LAST", cwd.buff);
+
+		int fd = open(reply_messages_file.buff, O_WRONLY | O_TRUNC | O_CREAT, S_IRUSR | S_IWUSR);
+		if (fd < 0)
+			FATAL(FILE_OPEN_FAILED, reply_messages_file.buff);
+
+		INFO("decrypting messages, this may take a few seconds");
+
+		struct graph_traversal_context cb_ctx = { .gpg_ctx = &gpg_ctx, .message_fd = fd };
+		ret = traverse_commit_graph(NULL, compose, commit_traversal_cb, &cb_ctx);
+		if (ret)
+			FATAL("commit graph traversal failed");
+
+		close(fd);
+
+		ret = launch_editor(compose_file.buff, reply_messages_file.buff);
+
+		create_truncate_file(reply_messages_file.buff);
+		strbuf_release(&reply_messages_file);
+
+		gpgme_context_release(&gpg_ctx);
+	} else {
+		ret = launch_editor(compose_file.buff, NULL);
+	}
+
+	if (ret)
+		DIE("vim exited unexpectedly (status %d)", ret);
+
+	int fd = open(compose_file.buff, O_RDONLY);
+	if (fd < 0)
+		FATAL(FILE_OPEN_FAILED, compose_file.buff);
+
+	strbuf_attach_fd(buff, fd);
+	close(fd);
+
+	create_truncate_file(compose_file.buff);
+	strbuf_release(&compose_file);
+	strbuf_release(&cwd);
+}
+
+/**
+ * Read the contents of a given file into the strbuf. If file_path is "-",
+ * read from stdin instead.
+ * */
+static void read_message_from_file(const char *file_path, struct strbuf *buff)
+{
+	int fd = STDIN_FILENO;
+
+	int read_stdin = !strcmp(file_path, "-");
+	if (!read_stdin) {
+		fd = open(file_path, O_RDONLY);
+		if (fd < 0)
+			DIE(FILE_OPEN_FAILED, file_path);
+	} else
+		fprintf(stderr, "[INFO] Type your message below. Once complete, press ⌃D to exit.\n");
+
+	strbuf_attach_fd(buff, fd);
+
+	if (!read_stdin)
+		close(fd);
+}
+
+/**
+ * Filter function used by encrypt_message(...) to filter any keys that are not
+ * specified in a recipients str_array (given as the data argument).
+ *
+ * Keys are filtered if:
+ * - no recipients match the primary key fingerprint
+ * - no recipients match any subkey uid field
+ * - no recipients match any subkey name field
+ * - no recipients match any subkey email field
+ * - no recipients match any subkey comment field
+ * - no recipients match any subkey address field
+ * */
+static int filter_gpg_keylist_by_recipients(struct _gpgme_key *key, void *data)
+{
+	struct str_array *recipients = (struct str_array *)data;
+
+	for (size_t index = 0; index < recipients->len; index++) {
+		const char *recipient = str_array_get(recipients, index);
+		if (key->fpr && !strcmp(key->fpr, recipient))
+			return 1;
+
+		struct _gpgme_user_id *uid = key->uids;
+		while (uid) {
+			if (uid->uid && !strcmp(uid->uid, recipient))
+				return 1;
+			if (uid->name && !strcmp(uid->name, recipient))
+				return 1;
+			if (uid->email && !strcmp(uid->email, recipient))
+				return 1;
+			if (uid->comment && !strcmp(uid->comment, recipient))
+				return 1;
+			if (uid->address && !strcmp(uid->address, recipient))
+				return 1;
+
+			uid = uid->next;
+		}
+	}
 
 	return 0;
 }
@@ -179,141 +304,6 @@ static int encrypt_message_asym(struct gc_gpgme_ctx *ctx, struct str_array *reci
 }
 
 /**
- * Allow the user to compose a message by running vim as a child process
- * and reading the contents of the file into the given strbuf.
- *
- * This function does not use temporary files. Instead, it uses .git/COMMIT_EDITMSG.
- * The file is first truncated to zero bytes, then vim is opened to write to the file.
- * Once vim exits, the file is read into the given buffer, and then the file is truncated
- * once more.
- *
- * This is inherently insecure, and when we start to harden git-chat, this functionality
- * could be removed.
- * */
-static void compose_message(struct strbuf *buff)
-{
-	struct child_process_def cmd;
-	struct strbuf path_buff;
-
-	char buffer[BUFF_LEN];
-	ssize_t bytes_read = 0;
-	int status;
-
-	strbuf_init(&path_buff);
-	if (get_cwd(&path_buff))
-		FATAL("unable to obtain the current working directory from getcwd()");
-	strbuf_attach_str(&path_buff, "/.git/GC_EDITMSG");
-
-	const char *msg_compose_file = path_buff.buff;
-
-	// clear the contents of GC_EDITMSG
-	int fd = open(msg_compose_file, O_WRONLY | O_TRUNC | O_CREAT,
-			S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
-	if (fd < 0)
-		FATAL(FILE_OPEN_FAILED, msg_compose_file);
-	close(fd);
-
-	// open vim without backup on GC_EDITMSG
-	child_process_def_init(&cmd);
-	cmd.executable = "vim";
-	argv_array_push(&cmd.args, "-c", "set nobackup nowritebackup", "-n",
-			msg_compose_file, NULL);
-
-	status = run_command(&cmd);
-	if (status)
-		DIE("Vim editor failed with exit status '%d'", status);
-
-	child_process_def_release(&cmd);
-
-	// when vim closes, read GC_EDITMSG into strbuf
-	fd = open(msg_compose_file, O_RDONLY);
-	if (fd < 0)
-		FATAL(FILE_OPEN_FAILED, msg_compose_file);
-
-	while ((bytes_read = xread(fd, buffer, BUFF_LEN)) > 0)
-		strbuf_attach(buff, buffer, bytes_read);
-
-	if (bytes_read < 0)
-		FATAL("Unable to read message from file; failed to read from file descriptor.");
-
-	close(fd);
-
-	// clear the contents of GC_EDITMSG
-	unlink(msg_compose_file);
-
-	strbuf_release(&path_buff);
-}
-
-/**
- * Read the contents of a given file into the strbuf. If file_path is "-",
- * read from stdin instead.
- * */
-static void read_message_from_file(const char *file_path, struct strbuf *buff)
-{
-	char buffer[BUFF_LEN];
-	int fd = STDIN_FILENO;
-
-	int read_stdin = !strcmp(file_path, "-");
-	if (!read_stdin) {
-		fd = open(file_path, O_RDONLY);
-		if (fd < 0)
-			DIE(FILE_OPEN_FAILED, file_path);
-	} else
-		fprintf(stderr, "[INFO] Type your message below. Once complete, press ⌃D to exit.\n");
-
-	ssize_t bytes_read = 0;
-	while ((bytes_read = xread(fd, buffer, BUFF_LEN)) > 0)
-		strbuf_attach(buff, buffer, bytes_read);
-
-	if (bytes_read < 0)
-		FATAL("Unable to read message; read() from file filed");
-
-	if (!read_stdin)
-		close(fd);
-}
-
-/**
- * Filter function used by encrypt_message(...) to filter any keys that are not
- * specified in a recipients str_array (given as the data argument).
- *
- * Keys are filtered if:
- * - no recipients match the primary key fingerprint
- * - no recipients match any subkey uid field
- * - no recipients match any subkey name field
- * - no recipients match any subkey email field
- * - no recipients match any subkey comment field
- * - no recipients match any subkey address field
- * */
-static int filter_gpg_keylist_by_recipients(struct _gpgme_key *key, void *data)
-{
-	struct str_array *recipients = (struct str_array *)data;
-
-	for (size_t index = 0; index < recipients->len; index++) {
-		const char *recipient = str_array_get(recipients, index);
-		if (key->fpr && !strcmp(key->fpr, recipient))
-			return 1;
-
-		struct _gpgme_user_id *uid = key->uids;
-		while (uid) {
-			if (uid->uid && !strcmp(uid->uid, recipient))
-				return 1;
-			if (uid->name && !strcmp(uid->name, recipient))
-				return 1;
-			if (uid->email && !strcmp(uid->email, recipient))
-				return 1;
-			if (uid->comment && !strcmp(uid->comment, recipient))
-				return 1;
-			if (uid->address && !strcmp(uid->address, recipient))
-				return 1;
-
-			uid = uid->next;
-		}
-	}
-
-	return 0;
-}
-
-/**
  * Create a new commit on the tip of the current branch whose commit message body
  * is the encrypted message. Returns the exit status from the git command that
  * was run.
@@ -355,4 +345,128 @@ static int write_commit(struct strbuf *encrypted_message)
 	child_process_def_release(&cmd);
 
 	return status;
+}
+
+/**
+ * Create a new message with the given recipients.
+ *
+ * The mutually-exclusive arguments `message` and `file` are used to supply
+ * the contents of the message. If both arguments are NULL, the editor
+ * is spawned to allow the user to compose the message.
+ *
+ * If `file` is non-null, the message content is read from a file with the
+ * given path, unless the path is `-` which will read the message from stdin.
+ *
+ * When `compose` is non-zero, that number of messages on the current channel
+ * will be decrypted and shown in the editor. This will only take effect if both
+ * `file` and `message` arguments are NULL.
+ *
+ * Message cannot be empty.
+ * */
+static int create_message(struct str_array *recipients, const char *message,
+		const char *file, int compose)
+{
+	struct gc_gpgme_ctx ctx;
+	struct strbuf message_buff, ciphertext, keys_dir_path;
+
+	if (!is_inside_git_chat_space())
+		DIE("Where are you? It doesn't look like you're in the right directory.");
+
+	strbuf_init(&message_buff);
+
+	// build the message into the message_buff buffer
+	if (!message && !file)
+		compose_message(&message_buff, compose);
+	else if (file)
+		read_message_from_file(file, &message_buff);
+	else
+		strbuf_attach_str(&message_buff, message);
+
+	if (!message_buff.len)
+		DIE("message aborted (message was not provided)");
+
+	strbuf_init(&keys_dir_path);
+	if (get_keys_dir(&keys_dir_path))
+		FATAL(".keys directory does not exist or cannot be used for some reason");
+
+	gpgme_context_init(&ctx, 1);
+	strbuf_init(&ciphertext);
+
+	// reimport the gpg keys into the keyring
+	rebuild_gpg_keyring(&ctx, keys_dir_path.buff);
+	strbuf_release(&keys_dir_path);
+
+	int ret = encrypt_message_asym(&ctx, recipients, &message_buff, &ciphertext);
+	if (ret == 0)
+		DIE("no message recipients; no one will be able to read your message.");
+	if (ret < 0)
+		DIE("one or more message recipients have no public gpg key available.");
+
+	gpgme_context_release(&ctx);
+
+	memset(message_buff.buff, 0, message_buff.alloc);
+
+	if (write_commit(&ciphertext))
+		FATAL("failed to write ciphertext as the commit message body");
+
+	strbuf_release(&message_buff);
+	strbuf_release(&ciphertext);
+
+	return 0;
+}
+
+int cmd_message(int argc, char *argv[])
+{
+	int show_help = 0;
+	int reply = 0, compose = 0;
+	struct str_array recipients;
+	const char *message = NULL;
+	const char *file = NULL;
+
+	const struct command_option message_cmd_options[] = {
+			OPT_LONG_STRING_LIST("recipient", "alias", "specify one or more recipients that may read the message", &recipients),
+			OPT_STRING('m', "message", "message", "provide the message contents", &message),
+			OPT_STRING('f', "file", "filename", "read message contents from file", &file),
+			OPT_LONG_BOOL("reply", "show the last message when composing new messages", &reply),
+			OPT_LONG_INT("compose", "show last messages when composing new messages", &compose),
+			OPT_BOOL('h', "help", "show usage and exit", &show_help),
+			OPT_END()
+	};
+
+	str_array_init(&recipients);
+	argc = parse_options(argc, argv, message_cmd_options, 1, 1);
+	if (argc > 0) {
+		show_usage_with_options(message_cmd_usage, message_cmd_options, 1,
+				"error: unknown option '%s'", argv[0]);
+		str_array_release(&recipients);
+		return 1;
+	}
+
+	if (show_help) {
+		show_usage_with_options(message_cmd_usage, message_cmd_options, 0, NULL);
+		str_array_release(&recipients);
+		return 0;
+	}
+
+	if (message && file) {
+		show_usage_with_options(message_cmd_usage, message_cmd_options, 1,
+				"error: mixing --message and --file is not supported");
+		str_array_release(&recipients);
+		return 1;
+	}
+
+	if (compose < 0) {
+		show_usage_with_options(message_cmd_usage, message_cmd_options, 1,
+				"error: --reply-last value must be non-negative");
+		str_array_release(&recipients);
+		return 1;
+	}
+
+	// reply-last option takes precedence
+	compose = (compose > 0) ? compose : reply;
+
+	int ret = create_message(&recipients, message, file, compose);
+
+	str_array_release(&recipients);
+	return ret;
 }

--- a/src/builtin/read.c
+++ b/src/builtin/read.c
@@ -1,34 +1,11 @@
-#include <stdlib.h>
 #include <unistd.h>
-#include <string.h>
-#include <sys/time.h>
 
+#include "git/graph-traversal.h"
+#include "gnupg/gpg-common.h"
+#include "working-tree.h"
 #include "parse-options.h"
-#include "run-command.h"
-#include "str-array.h"
-#include "strbuf.h"
 #include "paging.h"
 #include "utils.h"
-#include "working-tree.h"
-#include "gnupg/gpg-common.h"
-#include "git/commit.h"
-
-#define READ 0
-#define WRITE 1
-#define BUFF_LEN 1024
-#define DELIM_LEN 16
-
-enum message_type {
-	PLAINTEXT,
-	DECRYPTED,
-	UNKNOWN_ERROR
-};
-
-struct object_summary {
-	char oid[GIT_HEX_OBJECT_ID];
-	long object_len;
-	size_t summary_line_len;
-};
 
 static const struct usage_string read_cmd_usage[] = {
 		USAGE("git chat read [(-n | --max-count) <n>] [--no-color] [<commit hash>]"),
@@ -36,397 +13,60 @@ static const struct usage_string read_cmd_usage[] = {
 		USAGE_END()
 };
 
-static int no_color = 0;
+struct graph_traversal_context {
+	int no_color;
+	struct gc_gpgme_ctx *gpg_ctx;
+};
 
-/**
- * Pretty-print a single message.
- *
- * Messages are displayed in the following format:
- * [<timestamp> <ENC | PLN> <author>]
- *   <message>...
- *   <message>...
- * */
-static void pretty_print_message(struct git_commit *commit, struct strbuf *message,
-		enum message_type type)
+static int commit_traversal_cb(struct git_commit *commit, void *data)
 {
-	struct strbuf meta, formatted_message;
-	strbuf_init(&meta);
-	strbuf_init(&formatted_message);
+	struct graph_traversal_context *ctx = (struct graph_traversal_context *) data;
+	struct gc_gpgme_ctx *gpg_ctx = ctx->gpg_ctx;
+	int no_color = ctx->no_color;
 
-	time_t epoch = commit->author.timestamp.time;
+	struct strbuf decrypted_text;
+	strbuf_init(&decrypted_text);
 
-	const char *color_enable;
-	const char *flag_str;
-	switch (type) {
-		case DECRYPTED:
-			flag_str = "DEC";
-			color_enable = ANSI_COLOR_GREEN;
-			break;
-		case PLAINTEXT:
-			flag_str = "PLN";
-			color_enable = ANSI_COLOR_CYAN;
-			break;
-		case UNKNOWN_ERROR:
-			flag_str = "ERR";
-			color_enable = ANSI_COLOR_RED;
-			break;
-		default:
-			flag_str = "???";
-			color_enable = ANSI_COLOR_RED;
+	int ret = decrypt_asymmetric_message(gpg_ctx, &commit->body, &decrypted_text);
+	if (!ret) {
+		// decryption successful
+		pretty_print_message(commit, &decrypted_text, DECRYPTED, no_color, STDOUT_FILENO);
+	} else if (ret > 0) {
+		// commit body is not gpg message; print commit message body
+		pretty_print_message(commit, &commit->body, PLAINTEXT, no_color, STDOUT_FILENO);
+	} else {
+		strbuf_clear(&decrypted_text);
+		strbuf_attach_str(&decrypted_text, "message could not be decrypted.");
+		pretty_print_message(commit, &decrypted_text, UNKNOWN_ERROR, no_color, STDOUT_FILENO);
 	}
 
-	color_enable = no_color ? "" : color_enable;
-	const char *color_reset = no_color ? "" : ANSI_COLOR_RESET;
+	fflush(stdout);
 
-	struct tm *info;
-	info = localtime(&epoch);
-	strbuf_attach_fmt(&meta, "%s", asctime(info));
-	strbuf_trim(&meta);
-	strbuf_attach_fmt(&meta, " %s %s", flag_str, commit->author.name.buff);
-
-	strbuf_trim(message);
-
-	struct str_array lines;
-	str_array_init(&lines);
-
-	int line_count = strbuf_split(message, "\n", &lines);
-	for (int i = 0; i < line_count; i++) {
-		char *line = str_array_get(&lines, i);
-		strbuf_attach_fmt(&formatted_message, "\n\t%s", line);
-	}
-
-	printf("%s[%s]%s\n%s\n\n", color_enable, meta.buff, color_reset,
-			formatted_message.buff);
-
-	str_array_release(&lines);
-	strbuf_release(&meta);
-	strbuf_release(&formatted_message);
-}
-
-/**
- * Replace 'X' characters in a null-terminated template string with randomly
- * generated printable hexadecimal digits.
- *
- * If delim is non-null, it is updated with the characters set in the template
- * string, up to 'len' characters.
- * */
-static void str_template_generate_delimiter(char *str, char *delim, size_t len)
-{
-	struct timeval time;
-	if (gettimeofday(&time, NULL))
-		FATAL("unable to seed PRNG; gettimeofday failed unexpectedly");
-
-	srandom((unsigned)time.tv_sec ^ (unsigned)time.tv_usec);
-
-	const char *hex_digits = "0123456789abcdef";
-	size_t delim_index = 0;
-	for (char *current = strchr(str, 'X'); current != NULL; current = strchr(current, 'X')) {
-		*current = hex_digits[random() % 16];
-
-		if (delim && delim_index < len) {
-			delim[delim_index++] = *current;
-		}
-	}
-}
-
-/**
- * Parse the summary line of batched git-cat-file output for commit id,
- * object length. Verify that the summary line is prefixed with the correct
- * delimiter.
- *
- * Returns zero if successful, negative if parsing failed, and positive if
- * not enough data has been read into the buffer.
- * */
-static int parse_git_cat_file_output_summary_line(char *output, size_t len,
-		struct object_summary *summary, char delim[DELIM_LEN])
-{
-	const char *expected_object_type = "commit";
-
-	char *lf = NULL;
-	char *commit_id = NULL;
-	char *object_type = NULL;
-	char *object_len_str = NULL;
-	char *tailptr = NULL;
-	size_t line_len;
-	size_t object_type_str_len;
-
-	// isolate object information line
-	lf = memchr(output, '\n', len);
-	if (!lf)
-		return 1;
-
-	// verify delim
-	line_len = lf - output;
-	if (line_len < DELIM_LEN) {
-		LOG_ERROR("failed to parse git-cat-file output; line not prefixed with delim");
-		return -1;
-	}
-
-	if (memcmp(delim, output, DELIM_LEN) != 0) {
-		LOG_ERROR("failed to parse git-cat-file output; "
-				  "invalid delim, expected '%.*s' but was '%.*s'",
-				DELIM_LEN, delim, DELIM_LEN, output);
-		return -1;
-	}
-
-	// parse commit id
-	commit_id = output + DELIM_LEN + 1;
-	if (commit_id >= lf || (lf - commit_id) < GIT_HEX_OBJECT_ID) {
-		LOG_ERROR("failed to parse git-cat-file output; no commit id present");
-		return -1;
-	}
-
-	// parse object type
-	object_type = commit_id + GIT_HEX_OBJECT_ID + 1;
-	object_type_str_len = strlen(expected_object_type);
-	if (object_type >= lf || (size_t)(lf - object_type) < object_type_str_len) {
-		LOG_ERROR("failed to parse git-cat-file output; expected object of "
-				  "type %s, but was unexpected type", expected_object_type);
-		return -1;
-	}
-
-	if (memcmp(object_type, expected_object_type, object_type_str_len) != 0) {
-		LOG_ERROR("failed to parse git-cat-file output; expected object of "
-				  "type %s, but was unexpected type", expected_object_type);
-		return -1;
-	}
-
-	// parse object length
-	object_len_str = object_type + object_type_str_len + 1;
-	if (object_len_str >= lf || !(lf - object_len_str)) {
-		LOG_ERROR("failed to parse git-cat-file output; unable to parse object length");
-		return -1;
-	}
-
-	tailptr = NULL;
-	long object_len = strtol(object_len_str, &tailptr, 0);
-	if (!tailptr || tailptr != lf) {
-		LOG_ERROR("failed to parse git-cat-file output; unable to parse object length");
-		return -1;
-	}
-
-	memcpy(summary->oid, commit_id, GIT_HEX_OBJECT_ID);
-	summary->object_len = object_len;
-	summary->summary_line_len = lf - output;
-	return 0;
-}
-
-/**
- * From batched git-cat-file output, attempt to parse a single commit object.
- *
- * Batched git-cat-file output has the format:
- * <commit id> <object type> <object size>
- * <object content>
- *
- * The expected format is quite similar, but introduces a random delimiter to
- * ensure that specially crafted commit messages cannot be used to mislead the
- * parser. The new git-cat-file output has the format:
- * <delim> <commit id> <object type> <object size>
- * <object content>
- *
- * This function attempts to parse commit objects from batched git-cat-file output,
- * stopping if an object is only partially read, or the parser failed to interpret
- * the output.
- *
- * As commit objects are read from the output buffer, the parsed data is removed
- * and any remaining data is left in the buffer.
- *
- * Returns zero if successful, and non-zero if the parser was unable to interpret
- * the data, or critical information couldn't be read from the object summary line.
- * */
-static int parse_git_cat_file_output(struct str_array *commits,
-		struct strbuf *cat_file_out_buf, char delim[DELIM_LEN])
-{
-	do {
-		struct object_summary summary;
-		int ret = parse_git_cat_file_output_summary_line(cat_file_out_buf->buff,
-				cat_file_out_buf->len, &summary, delim);
-		if (ret < 0)
-			return 1;
-		if (ret > 0)
-			break;
-
-		// verify full object exists in buffer
-		char *object = cat_file_out_buf->buff + summary.summary_line_len + 1;
-		if ((object + summary.object_len + 1) > (cat_file_out_buf->buff + cat_file_out_buf->len))
-			break;
-
-		struct git_commit *commit = (struct git_commit *) malloc(sizeof(struct git_commit));
-		git_commit_object_init(commit);
-		if (commit_parse(commit, summary.oid, object, summary.object_len)) {
-			LOG_ERROR("failed to parse commit object from git-cat-file output");
-			git_commit_object_release(commit);
-			free(commit);
-			return 1;
-		}
-
-		// shift buffer
-		strbuf_remove(cat_file_out_buf, 0, object + summary.object_len - cat_file_out_buf->buff + 1);
-
-		struct str_array_entry *entry = str_array_insert_nodup(commits, NULL, commits->len);
-		entry->data = commit;
-	} while (1);
+	strbuf_release(&decrypted_text);
 
 	return 0;
 }
 
-/**
- *
- */
-static ssize_t read_messages_single_pass(struct gc_gpgme_ctx *ctx,
-		int object_stream, struct strbuf *buffer, char delim[DELIM_LEN])
+static int read_messages(const char *commit, int limit, int no_color)
 {
-	struct str_array parsed_commits;
-	str_array_init(&parsed_commits);
-	char tmp[BUFF_LEN];
-
-	ssize_t bytes_read = xread(object_stream, tmp, BUFF_LEN);
-	if (bytes_read < 0)
-		FATAL("failed to read from git-cat-file process");
-	if (bytes_read > 0)
-		strbuf_attach(buffer, tmp, bytes_read);
-
-	if (parse_git_cat_file_output(&parsed_commits, buffer, delim))
-		FATAL("failed to parse batched git-cat-file output");
-	for (size_t i = 0; i < parsed_commits.len; i++) {
-		struct str_array_entry *entry = str_array_get_entry(&parsed_commits, i);
-		struct git_commit *commit = (struct git_commit *) entry->data;
-
-		// attempt to decrypt message
-		struct strbuf decrypted_message;
-		strbuf_init(&decrypted_message);
-
-		int ret = decrypt_asymmetric_message(ctx, &commit->body, &decrypted_message);
-		if (!ret) {
-			// decryption successful
-			pretty_print_message(commit, &decrypted_message, DECRYPTED);
-		} else if (ret > 0) {
-			// commit body is not gpg message; print commit message body
-			pretty_print_message(commit, &commit->body, PLAINTEXT);
-		} else {
-			strbuf_clear(&decrypted_message);
-			strbuf_attach_str(&decrypted_message, "message could not be decrypted.");
-			pretty_print_message(commit, &decrypted_message, UNKNOWN_ERROR);
-		}
-
-		fflush(stdout);
-
-		strbuf_release(&decrypted_message);
-		git_commit_object_release(commit);
-		free(entry->data);
-	}
-
-	str_array_release(&parsed_commits);
-
-	return bytes_read;
-}
-
-/**
- * Decrypt and display messages in reverse-chronological order. If the commit_id
- * argument is NULL, displays all messages (up to limit, or all if negative),
- * otherwise simply displays the specific message.
- *
- * Returns zero if successful, and non-zero otherwise.
- * */
-static int read_messages(const char *commit_id, int limit)
-{
-	struct child_process_def rev_list_proc, cat_file_proc;
-	struct gc_gpgme_ctx ctx;
-	int rev_list_exit, cat_file_exit;
-
-	gpgme_context_init(&ctx, 0);
-
-	/* git-rev-list to read commit objects in reverse chronological order.
-	 *
-	 * Traverse the commit graph following the first parent if merge commits are
-	 * encountered, and skipping such merge commits. We are relying on having a
-	 * pretty clean commit graph here, and this might start to break down if the
-	 * user tries to mess with the commit graph (introducing merges, for instance).
-	 */
-	child_process_def_init(&rev_list_proc);
-	rev_list_proc.git_cmd = 1;
-
-	child_process_def_stdout(&rev_list_proc, STDOUT_PROVISIONED);
-	if (pipe(rev_list_proc.out_fd) < 0)
-		FATAL("invocation of pipe() system call failed.");
-
-	struct strbuf count;
-	strbuf_init(&count);
-	strbuf_attach_fmt(&count, "%d", limit);
-
-	argv_array_push(&rev_list_proc.args, "rev-list", "--first-parent", "--no-merges",
-			"--max-count", commit_id ? "1" : count.buff, commit_id ? commit_id : "HEAD", NULL);
-
-	/*
-	 * git-cat-file in batch mode to print commit object for commit ids read from git-rev-list.
-	 *
-	 * The git-cat-file child process is chained to the git-rev-list child process,
-	 * such that the output from git-rev-list is fed into the input of git-cat-file.
-	 * With this configuration, we only need to read commit object data from
-	 * the cat-file output stream.
-	 * */
-	child_process_def_init(&cat_file_proc);
-	cat_file_proc.git_cmd = 1;
-
-	child_process_def_stdin(&cat_file_proc, STDIN_PROVISIONED);
-	cat_file_proc.in_fd[READ] = rev_list_proc.out_fd[READ];
-	cat_file_proc.in_fd[WRITE] = rev_list_proc.out_fd[WRITE];
-
-	child_process_def_stdout(&cat_file_proc, STDOUT_PROVISIONED);
-	if (pipe(cat_file_proc.out_fd) < 0)
-		FATAL("invocation of pipe() system call failed.");
-
-	/* A delimiter is generated and used to securely delimit cat-file output.
-	 * Without it, specially crafted commit messages could be used to trick
-	 * the parser into doing something it's not supposed to.
-	 * */
-	char delim[DELIM_LEN];
-	char format_arg[] = "--batch=XXXXXXXXXXXXXXXX %(objectname) %(objecttype) %(objectsize)";
-	str_template_generate_delimiter(format_arg, delim, DELIM_LEN);
-	argv_array_push(&cat_file_proc.args, "cat-file", format_arg, NULL);
-
-	start_command(&rev_list_proc);
-	start_command(&cat_file_proc);
-	close(cat_file_proc.in_fd[READ]);
-	close(cat_file_proc.in_fd[WRITE]);
-	close(cat_file_proc.out_fd[WRITE]);
+	struct gc_gpgme_ctx gpg_ctx;
+	gpgme_context_init(&gpg_ctx, 0);
 
 	pager_start(GIT_CHAT_PAGER_RAW_CTRL_CHR | GIT_CHAT_PAGER_CLR_SCRN);
 
-	struct strbuf cat_file_out_buf;
-	strbuf_init(&cat_file_out_buf);
+	struct graph_traversal_context ctx = { .no_color = no_color, .gpg_ctx = &gpg_ctx };
+	int ret = traverse_commit_graph(commit, limit, commit_traversal_cb, &ctx);
+	if (ret)
+		FATAL("commit graph traversal failed");
 
-	ssize_t bytes_read;
-	do {
-		bytes_read = read_messages_single_pass(&ctx,
-				cat_file_proc.out_fd[READ], &cat_file_out_buf, delim);
-	} while (bytes_read > 0 || cat_file_out_buf.len > 0);
-
-	strbuf_release(&cat_file_out_buf);
-
-	close(rev_list_proc.out_fd[WRITE]);
-	rev_list_exit = finish_command(&rev_list_proc);
-	child_process_def_release(&rev_list_proc);
-
-	strbuf_release(&count);
-
-	close(cat_file_proc.out_fd[READ]);
-	cat_file_exit = finish_command(&cat_file_proc);
-	child_process_def_release(&cat_file_proc);
-
-	gpgme_context_release(&ctx);
-
-	if (rev_list_exit)
-		return rev_list_exit;
-	if (cat_file_exit)
-		return cat_file_exit;
-
+	gpgme_context_release(&gpg_ctx);
 	return 0;
 }
 
 int cmd_read(int argc, char *argv[])
 {
 	int limit = -1;
+	int no_color = 0;
 	int show_help = 0;
 
 	const struct command_option options[] = {
@@ -454,5 +94,5 @@ int cmd_read(int argc, char *argv[])
 	if (!isatty(STDOUT_FILENO))
 		no_color = 1;
 
-	return read_messages(argc ? argv[0] : NULL, limit);
+	return read_messages(argc ? argv[0] : NULL, limit, no_color);
 }

--- a/src/git/graph-traversal.c
+++ b/src/git/graph-traversal.c
@@ -1,0 +1,324 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/time.h>
+
+#include "git/graph-traversal.h"
+#include "git/commit.h"
+#include "run-command.h"
+#include "str-array.h"
+#include "strbuf.h"
+#include "utils.h"
+
+#define READ 0
+#define WRITE 1
+#define BUFF_LEN 1024
+#define DELIM_LEN 16
+
+struct object_summary {
+	char oid[GIT_HEX_OBJECT_ID];
+	long object_len;
+	size_t summary_line_len;
+};
+
+/**
+ * Replace 'X' characters in a null-terminated template string with randomly
+ * generated printable hexadecimal digits.
+ *
+ * If delim is non-null, it is updated with the characters set in the template
+ * string, up to 'len' characters.
+ * */
+static void str_template_generate_delimiter(char *str, char *delim, size_t len)
+{
+	struct timeval time;
+	if (gettimeofday(&time, NULL))
+		FATAL("unable to seed PRNG; gettimeofday failed unexpectedly");
+
+	srandom((unsigned)time.tv_sec ^ (unsigned)time.tv_usec);
+
+	const char *hex_digits = "0123456789abcdef";
+	size_t delim_index = 0;
+	for (char *current = strchr(str, 'X'); current != NULL; current = strchr(current, 'X')) {
+		*current = hex_digits[random() % 16];
+
+		if (delim && delim_index < len) {
+			delim[delim_index++] = *current;
+		}
+	}
+}
+
+/**
+ * Parse the summary line of batched git-cat-file output for commit id,
+ * object length. Verify that the summary line is prefixed with the correct
+ * delimiter.
+ *
+ * Returns zero if successful, negative if parsing failed, and positive if
+ * not enough data has been read into the buffer.
+ * */
+static int parse_git_cat_file_output_summary_line(char *output, size_t len,
+		struct object_summary *summary, char delim[DELIM_LEN])
+{
+	const char *expected_object_type = "commit";
+
+	char *lf = NULL;
+	char *commit_id = NULL;
+	char *object_type = NULL;
+	char *object_len_str = NULL;
+	char *tailptr = NULL;
+	size_t line_len;
+	size_t object_type_str_len;
+
+	// isolate object information line
+	lf = memchr(output, '\n', len);
+	if (!lf)
+		return 1;
+
+	// verify delim
+	line_len = lf - output;
+	if (line_len < DELIM_LEN) {
+		LOG_ERROR("failed to parse git-cat-file output; line not prefixed with delim");
+		return -1;
+	}
+
+	if (memcmp(delim, output, DELIM_LEN) != 0) {
+		LOG_ERROR("failed to parse git-cat-file output; "
+				  "invalid delim, expected '%.*s' but was '%.*s'",
+				DELIM_LEN, delim, DELIM_LEN, output);
+		return -1;
+	}
+
+	// parse commit id
+	commit_id = output + DELIM_LEN + 1;
+	if (commit_id >= lf || (lf - commit_id) < GIT_HEX_OBJECT_ID) {
+		LOG_ERROR("failed to parse git-cat-file output; no commit id present");
+		return -1;
+	}
+
+	// parse object type
+	object_type = commit_id + GIT_HEX_OBJECT_ID + 1;
+	object_type_str_len = strlen(expected_object_type);
+	if (object_type >= lf || (size_t)(lf - object_type) < object_type_str_len) {
+		LOG_ERROR("failed to parse git-cat-file output; expected object of "
+				  "type %s, but was unexpected type", expected_object_type);
+		return -1;
+	}
+
+	if (memcmp(object_type, expected_object_type, object_type_str_len) != 0) {
+		LOG_ERROR("failed to parse git-cat-file output; expected object of "
+				  "type %s, but was unexpected type", expected_object_type);
+		return -1;
+	}
+
+	// parse object length
+	object_len_str = object_type + object_type_str_len + 1;
+	if (object_len_str >= lf || !(lf - object_len_str)) {
+		LOG_ERROR("failed to parse git-cat-file output; unable to parse object length");
+		return -1;
+	}
+
+	tailptr = NULL;
+	long object_len = strtol(object_len_str, &tailptr, 0);
+	if (!tailptr || tailptr != lf) {
+		LOG_ERROR("failed to parse git-cat-file output; unable to parse object length");
+		return -1;
+	}
+
+	memcpy(summary->oid, commit_id, GIT_HEX_OBJECT_ID);
+	summary->object_len = object_len;
+	summary->summary_line_len = lf - output;
+	return 0;
+}
+
+/**
+ * From batched git-cat-file output, attempt to parse a single commit object.
+ *
+ * Batched git-cat-file output has the format:
+ * <commit id> <object type> <object size>
+ * <object content>
+ *
+ * The expected format is quite similar, but introduces a random delimiter to
+ * ensure that specially crafted commit messages cannot be used to mislead the
+ * parser. The new git-cat-file output has the format:
+ * <delim> <commit id> <object type> <object size>
+ * <object content>
+ *
+ * This function attempts to parse commit objects from batched git-cat-file output,
+ * stopping if an object is only partially read, or the parser failed to interpret
+ * the output.
+ *
+ * As commit objects are read from the output buffer, the parsed data is removed
+ * and any remaining data is left in the buffer.
+ *
+ * Returns zero if successful, and non-zero if the parser was unable to interpret
+ * the data, or critical information couldn't be read from the object summary line.
+ * */
+static int parse_git_cat_file_output(struct str_array *commits,
+		struct strbuf *cat_file_out_buf, char delim[DELIM_LEN])
+{
+	do {
+		struct object_summary summary;
+		int ret = parse_git_cat_file_output_summary_line(cat_file_out_buf->buff,
+				cat_file_out_buf->len, &summary, delim);
+		if (ret < 0)
+			return 1;
+		if (ret > 0)
+			break;
+
+		// verify full object exists in buffer
+		char *object = cat_file_out_buf->buff + summary.summary_line_len + 1;
+		if ((object + summary.object_len + 1) > (cat_file_out_buf->buff + cat_file_out_buf->len))
+			break;
+
+		struct git_commit *commit = (struct git_commit *) malloc(sizeof(struct git_commit));
+		git_commit_object_init(commit);
+		if (commit_parse(commit, summary.oid, object, summary.object_len)) {
+			LOG_ERROR("failed to parse commit object from git-cat-file output");
+			git_commit_object_release(commit);
+			free(commit);
+			return 1;
+		}
+
+		// shift buffer
+		strbuf_remove(cat_file_out_buf, 0, object + summary.object_len - cat_file_out_buf->buff + 1);
+
+		struct str_array_entry *entry = str_array_insert_nodup(commits, NULL, commits->len);
+		entry->data = commit;
+	} while (1);
+
+	return 0;
+}
+
+/**
+ *
+ *
+ * Return zero if successful, 1 if no data is remaining, and -1
+ * if the callback returned non-zero.
+ */
+static int read_messages_single_pass(int object_stream,
+		struct strbuf *buffer, char delim[DELIM_LEN], graph_traversal_cb cb,
+		void *data)
+{
+	struct str_array parsed_commits;
+	str_array_init(&parsed_commits);
+	char tmp[BUFF_LEN];
+
+	ssize_t bytes_read = xread(object_stream, tmp, BUFF_LEN);
+	if (bytes_read < 0)
+		FATAL("failed to read from git-cat-file process");
+	if (bytes_read > 0)
+		strbuf_attach(buffer, tmp, bytes_read);
+
+	if (parse_git_cat_file_output(&parsed_commits, buffer, delim))
+		FATAL("failed to parse batched git-cat-file output");
+
+	int ret = 0;
+	for (size_t i = 0; i < parsed_commits.len; i++) {
+		struct str_array_entry *entry = str_array_get_entry(&parsed_commits, i);
+		struct git_commit *commit = (struct git_commit *) entry->data;
+
+		// invoke callback
+		ret = cb(commit, data);
+		if (ret)
+			break;
+
+		git_commit_object_release(commit);
+		free(entry->data);
+	}
+
+	str_array_release(&parsed_commits);
+
+	if (ret)
+		return -1;
+
+	return bytes_read == 0;
+}
+
+int traverse_commit_graph(const char *commit, int limit, graph_traversal_cb cb,
+		void *data)
+{
+	struct child_process_def rev_list_proc, cat_file_proc;
+	int rev_list_exit, cat_file_exit;
+
+	/* git-rev-list to read commit objects in reverse chronological order.
+	 *
+	 * Traverse the commit graph following the first parent if merge commits are
+	 * encountered, and skipping such merge commits. We are relying on having a
+	 * pretty clean commit graph here, and this might start to break down if the
+	 * user tries to mess with the commit graph (introducing merges, for instance).
+	 */
+	child_process_def_init(&rev_list_proc);
+	rev_list_proc.git_cmd = 1;
+
+	child_process_def_stdout(&rev_list_proc, STDOUT_PROVISIONED);
+	if (pipe(rev_list_proc.out_fd) < 0)
+		FATAL("invocation of pipe() system call failed.");
+
+	struct strbuf count;
+	strbuf_init(&count);
+	strbuf_attach_fmt(&count, "%d", limit);
+
+	argv_array_push(&rev_list_proc.args, "rev-list", "--first-parent", "--no-merges",
+			"--max-count", commit ? "1" : count.buff, commit ? commit : "HEAD", NULL);
+
+	/*
+	 * git-cat-file in batch mode to print commit object for commit ids read from git-rev-list.
+	 *
+	 * The git-cat-file child process is chained to the git-rev-list child process,
+	 * such that the output from git-rev-list is fed into the input of git-cat-file.
+	 * With this configuration, we only need to read commit object data from
+	 * the cat-file output stream.
+	 * */
+	child_process_def_init(&cat_file_proc);
+	cat_file_proc.git_cmd = 1;
+
+	child_process_def_stdin(&cat_file_proc, STDIN_PROVISIONED);
+	cat_file_proc.in_fd[READ] = rev_list_proc.out_fd[READ];
+	cat_file_proc.in_fd[WRITE] = rev_list_proc.out_fd[WRITE];
+
+	child_process_def_stdout(&cat_file_proc, STDOUT_PROVISIONED);
+	if (pipe(cat_file_proc.out_fd) < 0)
+		FATAL("invocation of pipe() system call failed.");
+
+	/* A delimiter is generated and used to securely delimit cat-file output.
+	 * Without it, specially crafted commit messages could be used to trick
+	 * the parser into doing something it's not supposed to.
+	 * */
+	char delim[DELIM_LEN];
+	char format_arg[] = "--batch=XXXXXXXXXXXXXXXX %(objectname) %(objecttype) %(objectsize)";
+	str_template_generate_delimiter(format_arg, delim, DELIM_LEN);
+	argv_array_push(&cat_file_proc.args, "cat-file", format_arg, NULL);
+
+	start_command(&rev_list_proc);
+	start_command(&cat_file_proc);
+	close(cat_file_proc.in_fd[READ]);
+	close(cat_file_proc.in_fd[WRITE]);
+	close(cat_file_proc.out_fd[WRITE]);
+
+	struct strbuf cat_file_out_buf;
+	strbuf_init(&cat_file_out_buf);
+
+	int result;
+	do {
+		result = read_messages_single_pass(cat_file_proc.out_fd[READ],
+				&cat_file_out_buf, delim, cb, data);
+	} while (!result || cat_file_out_buf.len > 0);
+
+	strbuf_release(&cat_file_out_buf);
+
+	close(rev_list_proc.out_fd[WRITE]);
+	rev_list_exit = finish_command(&rev_list_proc);
+	child_process_def_release(&rev_list_proc);
+
+	strbuf_release(&count);
+
+	close(cat_file_proc.out_fd[READ]);
+	cat_file_exit = finish_command(&cat_file_proc);
+	child_process_def_release(&cat_file_proc);
+
+	if (rev_list_exit || cat_file_exit)
+		return -1;
+	if (result < 0)
+		return 1;
+
+	return 0;
+}

--- a/src/run-command.c
+++ b/src/run-command.c
@@ -86,14 +86,7 @@ int capture_command(struct child_process_def *cmd, struct strbuf *buffer)
 	start_command(cmd);
 	close(cmd->out_fd[WRITE]);
 
-	char out_buffer[BUFF_LEN];
-	ssize_t bytes_read = 0;
-	while ((bytes_read = xread(cmd->out_fd[READ], out_buffer, BUFF_LEN)) > 0)
-		strbuf_attach(buffer, out_buffer, bytes_read);
-
-	if (bytes_read < 0)
-		FATAL("failed to read from pipe to child process.");
-
+	strbuf_attach_fd(buffer, cmd->out_fd[READ]);
 	close(cmd->out_fd[READ]);
 
 	return finish_command(cmd);

--- a/src/strbuf.c
+++ b/src/strbuf.c
@@ -80,16 +80,27 @@ void strbuf_attach_vfmt(struct strbuf *buff, const char *fmt, va_list varargs)
 	// calculate required buffer size
 	ssize_t len = vsnprintf(NULL, 0, fmt, varargs_cpy);
 	if (len < 0)
-		FATAL("Unexpected error from vsnprintf()");
+		FATAL("unexpected error from vsnprintf()");
 
 	va_end(varargs_cpy);
 
 	strbuf_grow(buff, buff->alloc + len + 1);
 	len = vsnprintf(buff->buff + buff->len, len + 1, fmt, varargs);
 	if (len < 0)
-		FATAL("Unexpected error from vsnprintf()");
+		FATAL("unexpected error from vsnprintf()");
 
 	buff->len += len;
+}
+
+void strbuf_attach_fd(struct strbuf *buff, int fd)
+{
+	char temp_buffer[1024];
+	ssize_t bytes_read;
+	while ((bytes_read = xread(fd, temp_buffer, 1024)) > 0)
+		strbuf_attach(buff, temp_buffer, bytes_read);
+
+	if (bytes_read < 0)
+		FATAL("pipe read failure");
 }
 
 int strbuf_trim(struct strbuf *buff)

--- a/src/utils.c
+++ b/src/utils.c
@@ -55,6 +55,15 @@ void WARN(const char *fmt, ...)
 	va_end(varargs);
 }
 
+void INFO(const char *fmt, ...)
+{
+	va_list varargs;
+
+	va_start(varargs, fmt);
+	print_message(stderr, "info", fmt, varargs);
+	va_end(varargs);
+}
+
 static void print_message(FILE *output_stream, const char *prefix,
 		const char *fmt, va_list varargs)
 {
@@ -80,10 +89,6 @@ static void print_message(FILE *output_stream, const char *prefix,
 	}
 
 	fputs(message_buffer.buff, output_stream);
-
-	if (errno > 0)
-		fprintf(stderr, "%s\n", strerror(errno));
-
 	strbuf_release(&message_buffer);
 }
 


### PR DESCRIPTION
Introduced new --reply and --compose options to show decrypted messages
in a vim split window. This makes it easier to respond to messages.

Messages are decrypted and shown in the split window much in the same
way that messages are decrypted and shown in git-chat-read. To make this
work, the commit traversal machinery was pulled out of the git-chat-read
builtin and into it's own component, graph-traversal.