### PR TITLE
parse-options: improvements to type safety

### DIFF
--- a/include/parse-options.h
+++ b/include/parse-options.h
@@ -96,6 +96,12 @@ enum opt_type {
 	OPTION_END
 };
 
+union opt_arg_value_ptr {
+	int *int_ptr;
+	char **str_ptr;
+	struct str_array *str_array_ptr;
+};
+
 struct command_option;
 struct command_option {
 	const char s_flag;
@@ -103,7 +109,7 @@ struct command_option {
 	const char *str_name;
 	const char *desc;
 	enum opt_type type;
-	void *arg_value;
+	union opt_arg_value_ptr arg_value;
 };
 
 struct usage_string;
@@ -111,21 +117,21 @@ struct usage_string {
 	const char *usage_desc;
 };
 
-#define OPT_SHORT_BOOL(S,D,V)			{ (S), NULL,  NULL, (D), OPTION_BOOL_T, (V) }
-#define OPT_SHORT_INT(S,D,V)			{ (S), NULL,  NULL, (D), OPTION_INT_T, (V) }
-#define OPT_SHORT_STRING(S,N,D,V)		{ (S), NULL,  (N), (D), OPTION_STRING_T, (V) }
-#define OPT_SHORT_STRING_LIST(S,N,D,V)		{ (S), NULL,  (N), (D), OPTION_STRING_LIST_T, (V) }
-#define OPT_LONG_BOOL(L,D,V)			{ 0, (L),  NULL, (D), OPTION_BOOL_T, (V) }
-#define OPT_LONG_INT(L,D,V)				{ 0, (L),  NULL, (D), OPTION_INT_T, (V) }
-#define OPT_LONG_STRING(L,N,D,V)		{ 0, (L),  (N), (D), OPTION_STRING_T, (V) }
-#define OPT_LONG_STRING_LIST(L,N,D,V)		{ 0, (L),  (N), (D), OPTION_STRING_LIST_T, (V) }
-#define OPT_BOOL(S,L,D,V)				{ (S), (L), NULL, (D), OPTION_BOOL_T, (V) }
-#define OPT_INT(S,L,D,V)				{ (S), (L), NULL, (D), OPTION_INT_T, (V) }
-#define OPT_STRING(S,L,N,D,V)			{ (S), (L), (N), (D), OPTION_STRING_T, (V) }
-#define OPT_STRING_LIST(S,L,N,D,V)			{ (S), (L), (N), (D), OPTION_STRING_LIST_T, (V) }
-#define OPT_CMD(N,D,V)					{ 0, NULL, (N), (D), OPTION_COMMAND_T, (V) }
-#define OPT_GROUP(N)					{ 0, NULL, NULL, N, OPTION_GROUP_T, NULL }
-#define OPT_END()						{ 0, NULL, NULL, NULL, OPTION_END, NULL }
+#define OPT_SHORT_BOOL(S,D,V)			{ (S), NULL,  NULL, (D), OPTION_BOOL_T, { .int_ptr = (V) } }
+#define OPT_SHORT_INT(S,D,V)			{ (S), NULL,  NULL, (D), OPTION_INT_T, { .int_ptr = (V) } }
+#define OPT_SHORT_STRING(S,N,D,V)		{ (S), NULL,  (N), (D), OPTION_STRING_T, { .str_ptr = (V) } }
+#define OPT_SHORT_STRING_LIST(S,N,D,V)		{ (S), NULL,  (N), (D), OPTION_STRING_LIST_T, { .str_array_ptr = (V) } }
+#define OPT_LONG_BOOL(L,D,V)			{ 0, (L),  NULL, (D), OPTION_BOOL_T, { .int_ptr = (V) } }
+#define OPT_LONG_INT(L,D,V)				{ 0, (L),  NULL, (D), OPTION_INT_T, { .int_ptr = (V) } }
+#define OPT_LONG_STRING(L,N,D,V)		{ 0, (L),  (N), (D), OPTION_STRING_T, { .str_ptr = (V) } }
+#define OPT_LONG_STRING_LIST(L,N,D,V)		{ 0, (L),  (N), (D), OPTION_STRING_LIST_T, { .str_array_ptr = (V) } }
+#define OPT_BOOL(S,L,D,V)				{ (S), (L), NULL, (D), OPTION_BOOL_T, { .int_ptr = (V) } }
+#define OPT_INT(S,L,D,V)				{ (S), (L), NULL, (D), OPTION_INT_T, { .int_ptr = (V) } }
+#define OPT_STRING(S,L,N,D,V)			{ (S), (L), (N), (D), OPTION_STRING_T, { .str_ptr = (V) } }
+#define OPT_STRING_LIST(S,L,N,D,V)			{ (S), (L), (N), (D), OPTION_STRING_LIST_T, { .str_array_ptr = (V) } }
+#define OPT_CMD(N,D,V)					{ 0, NULL, (N), (D), OPTION_COMMAND_T, { .str_ptr = (V) } }
+#define OPT_GROUP(N)					{ 0, NULL, NULL, N, OPTION_GROUP_T }
+#define OPT_END()						{ 0, NULL, NULL, NULL, OPTION_END }
 
 #define USAGE(DESC)					{ (DESC) }
 #define USAGE_END()					{ NULL }

--- a/src/builtin/message.c
+++ b/src/builtin/message.c
@@ -420,8 +420,8 @@ int cmd_message(int argc, char *argv[])
 	int show_help = 0;
 	int reply = 0, compose = 0;
 	struct str_array recipients;
-	const char *message = NULL;
-	const char *file = NULL;
+	char *message = NULL;
+	char *file = NULL;
 
 	const struct command_option message_cmd_options[] = {
 			OPT_LONG_STRING_LIST("recipient", "alias", "specify one or more recipients that may read the message", &recipients),

--- a/src/parse-options.c
+++ b/src/parse-options.c
@@ -74,7 +74,7 @@ static int parse_long_option(int argc, char *argv[], int arg_index,
 		// if the argument is a boolean arg, set value to one and return
 		if (op->type == OPTION_BOOL_T && !strcmp(arg, op->l_flag)) {
 			array_shift(argv, arg_index, &new_len, 1);
-			*(int *) op->arg_value = 1;
+			*(int *) op->arg_value.int_ptr = 1;
 			break;
 		}
 
@@ -100,18 +100,18 @@ static int parse_long_option(int argc, char *argv[], int arg_index,
 				// verify that integer was parsed successfully
 				if (tailptr == (arg + strlen(arg))) {
 					array_shift(argv, arg_index, &new_len, 2);
-					*(int *) op->arg_value = (int) arg_value;
+					*(int *) op->arg_value.int_ptr = (int) arg_value;
 					break;
 				}
 			} else if (op->type == OPTION_STRING_T) {
 				array_shift(argv, arg_index, &new_len, 2);
 
-				*(char **) op->arg_value = arg;
+				*(char **) op->arg_value.str_ptr = arg;
 				break;
 			} else if (op->type == OPTION_STRING_LIST_T) {
 				array_shift(argv, arg_index, &new_len, 2);
 
-				str_array_push(op->arg_value, arg, NULL);
+				str_array_push(op->arg_value.str_array_ptr, arg, NULL);
 				break;
 			}
 		} else if (strlen(arg) > flag_len && arg[flag_len] == '=') {
@@ -125,18 +125,18 @@ static int parse_long_option(int argc, char *argv[], int arg_index,
 				// verify that integer was parsed successfully
 				if (tailptr == (arg + strlen(arg))) {
 					array_shift(argv, arg_index, &new_len, 1);
-					*(int *) op->arg_value = (int) arg_value;
+					*(int *) op->arg_value.int_ptr = (int) arg_value;
 					break;
 				}
 			} else if (op->type == OPTION_STRING_T) {
 				array_shift(argv, arg_index, &new_len, 1);
 
-				*(char **) op->arg_value = arg;
+				*(char **) op->arg_value.str_ptr = arg;
 				break;
 			} else if (op->type == OPTION_STRING_LIST_T) {
 				array_shift(argv, arg_index, &new_len, 1);
 
-				str_array_push(op->arg_value, arg, NULL);
+				str_array_push(op->arg_value.str_array_ptr, arg, NULL);
 				break;
 			}
 		}
@@ -163,7 +163,7 @@ static int parse_short_option(int argc, char *argv[], int arg_index,
 			}
 
 			if (op->type == OPTION_BOOL_T) {
-				*(int *) op->arg_value = 1;
+				*(int *) op->arg_value.int_ptr = 1;
 				break;
 			}
 
@@ -189,7 +189,7 @@ static int parse_short_option(int argc, char *argv[], int arg_index,
 					// verify that integer was parsed successfully
 					if (tailptr == (arg + strlen(arg))) {
 						array_shift(argv, arg_index, &new_len, 1);
-						*(int *) op->arg_value = (int) arg_value;
+						*(int *) op->arg_value.int_ptr = (int) arg_value;
 					}
 				} else {
 					arg = argv[arg_index + 1];
@@ -198,7 +198,7 @@ static int parse_short_option(int argc, char *argv[], int arg_index,
 					// verify that integer was parsed successfully
 					if (tailptr == (arg + strlen(arg))) {
 						array_shift(argv, arg_index, &new_len, 2);
-						*(int *) op->arg_value = (int) arg_value;
+						*(int *) op->arg_value.int_ptr = (int) arg_value;
 					}
 				}
 
@@ -209,7 +209,7 @@ static int parse_short_option(int argc, char *argv[], int arg_index,
 				arg = argv[arg_index + 1];
 				array_shift(argv, arg_index, &new_len, 2);
 
-				*(char **) op->arg_value = arg;
+				*(char **) op->arg_value.str_ptr = arg;
 				return argc - new_len;
 			}
 
@@ -217,7 +217,7 @@ static int parse_short_option(int argc, char *argv[], int arg_index,
 				arg = argv[arg_index + 1];
 				array_shift(argv, arg_index, &new_len, 2);
 
-				str_array_push(op->arg_value, arg, NULL);
+				str_array_push(op->arg_value.str_array_ptr, arg, NULL);
 				return argc - new_len;
 			}
 		}
@@ -236,8 +236,8 @@ static int parse_subcommand(char *argv[], int arg_index,
 
 		char *arg = argv[arg_index];
 		if (!strcmp(arg, op->str_name)) {
-			if (op->arg_value) {
-				*(int *) op->arg_value = 1;
+			if (op->arg_value.int_ptr) {
+				*(int *) op->arg_value.int_ptr = 1;
 			}
 
 			return 1;

--- a/test/unit/parse-options-test.c
+++ b/test/unit/parse-options-test.c
@@ -61,8 +61,8 @@ TEST_DEFINE(parse_options_short_bool_test)
 {
 	int bool_val_1 = 0;
 	int bool_val_2 = 0;
-	options[15].arg_value = &bool_val_1;
-	options[35].arg_value = &bool_val_2;
+	options[15].arg_value.int_ptr = &bool_val_1;
+	options[35].arg_value.int_ptr = &bool_val_2;
 
 	TEST_START() {
 		const int argc = 1;
@@ -75,8 +75,8 @@ TEST_DEFINE(parse_options_short_bool_test)
 		assert_false(bool_val_2);
 	}
 
-	options[15].arg_value = NULL;
-	options[35].arg_value = NULL;
+	options[15].arg_value.int_ptr = NULL;
+	options[35].arg_value.int_ptr = NULL;
 	TEST_END();
 }
 
@@ -87,11 +87,11 @@ TEST_DEFINE(parse_options_short_int_test)
 	int int_val_2 = 0;
 	int int_val_3 = 0;
 	int int_val_4 = 0;
-	options[1].arg_value = &bool_val_1;
-	options[38].arg_value = &int_val_1;
-	options[48].arg_value = &int_val_2;
-	options[49].arg_value = &int_val_3;
-	options[22].arg_value = &int_val_4;
+	options[1].arg_value.int_ptr = &bool_val_1;
+	options[38].arg_value.int_ptr = &int_val_1;
+	options[48].arg_value.int_ptr = &int_val_2;
+	options[49].arg_value.int_ptr = &int_val_3;
+	options[22].arg_value.int_ptr = &int_val_4;
 
 	TEST_START() {
 		int argc = 7;
@@ -121,10 +121,10 @@ TEST_DEFINE(parse_options_short_int_test)
 	}
 
 	// test teardown
-	options[1].arg_value = NULL;
-	options[38].arg_value = NULL;
-	options[48].arg_value = NULL;
-	options[49].arg_value = NULL;
+	options[1].arg_value.int_ptr = NULL;
+	options[38].arg_value.int_ptr = NULL;
+	options[48].arg_value.int_ptr = NULL;
+	options[49].arg_value.int_ptr = NULL;
 
 	TEST_END();
 }
@@ -134,8 +134,8 @@ TEST_DEFINE(parse_options_short_string_test)
 	char *str_1 = NULL;
 	char *str_2 = NULL;
 
-	options[8].arg_value = &str_1;
-	options[13].arg_value = &str_2;
+	options[8].arg_value.str_ptr = &str_1;
+	options[13].arg_value.str_ptr = &str_2;
 
 	TEST_START() {
 		int argc = 5;
@@ -149,8 +149,8 @@ TEST_DEFINE(parse_options_short_string_test)
 		assert_string_eq("-c", argv[0]);
 	}
 
-	options[8].arg_value = NULL;
-	options[13].arg_value = NULL;
+	options[8].arg_value.str_ptr = NULL;
+	options[13].arg_value.str_ptr = NULL;
 
 	TEST_END();
 }
@@ -160,7 +160,7 @@ TEST_DEFINE(parse_options_short_string_list_test)
 	struct str_array strings;
 	str_array_init(&strings);
 
-	options[46].arg_value = &strings;
+	options[46].arg_value.str_array_ptr = &strings;
 
 	TEST_START() {
 		int argc = 5;
@@ -175,7 +175,7 @@ TEST_DEFINE(parse_options_short_string_list_test)
 		assert_string_eq("-D", argv[0]);
 	}
 
-	options[46].arg_value = NULL;
+	options[46].arg_value.str_array_ptr = NULL;
 	str_array_release(&strings);
 
 	TEST_END();
@@ -186,9 +186,9 @@ TEST_DEFINE(parse_options_long_bool_test)
 	int bool_val_1 = 0;
 	int bool_val_2 = 0;
 	int bool_val_3 = 0;
-	options[14].arg_value = &bool_val_1;
-	options[20].arg_value = &bool_val_2;
-	options[26].arg_value = &bool_val_3;
+	options[14].arg_value.int_ptr = &bool_val_1;
+	options[20].arg_value.int_ptr = &bool_val_2;
+	options[26].arg_value.int_ptr = &bool_val_3;
 
 	TEST_START() {
 		const int argc = 3;
@@ -203,9 +203,9 @@ TEST_DEFINE(parse_options_long_bool_test)
 		assert_string_eq("--unknown-op", argv[0]);
 	}
 
-	options[14].arg_value = NULL;
-	options[20].arg_value = NULL;
-	options[26].arg_value = NULL;
+	options[14].arg_value.int_ptr = NULL;
+	options[20].arg_value.int_ptr = NULL;
+	options[26].arg_value.int_ptr = NULL;
 	TEST_END();
 }
 
@@ -213,8 +213,8 @@ TEST_DEFINE(parse_options_long_int_test)
 {
 	int int_val_1 = 0;
 	int int_val_2 = 0;
-	options[37].arg_value = &int_val_1;
-	options[39].arg_value = &int_val_2;
+	options[37].arg_value.int_ptr = &int_val_1;
+	options[39].arg_value.int_ptr = &int_val_2;
 
 	TEST_START() {
 		const int argc = 3;
@@ -227,8 +227,8 @@ TEST_DEFINE(parse_options_long_int_test)
 		assert_eq(int_val_2, -9);
 	}
 
-	options[37].arg_value = NULL;
-	options[39].arg_value = NULL;
+	options[37].arg_value.int_ptr = NULL;
+	options[39].arg_value.int_ptr = NULL;
 	TEST_END();
 }
 
@@ -237,9 +237,9 @@ TEST_DEFINE(parse_options_long_string_test)
 	char *string_val_1 = NULL;
 	char *string_val_2 = NULL;
 	char *string_val_3 = NULL;
-	options[4].arg_value = &string_val_1;
-	options[5].arg_value = &string_val_2;
-	options[16].arg_value = &string_val_3;
+	options[4].arg_value.str_ptr = &string_val_1;
+	options[5].arg_value.str_ptr = &string_val_2;
+	options[16].arg_value.str_ptr = &string_val_3;
 
 	TEST_START() {
 		const int argc = 6;
@@ -254,9 +254,9 @@ TEST_DEFINE(parse_options_long_string_test)
 		assert_string_eq("--reuse-message", argv[0]);
 	}
 
-	options[4].arg_value = NULL;
-	options[5].arg_value = NULL;
-	options[9].arg_value = NULL;
+	options[4].arg_value.str_ptr = NULL;
+	options[5].arg_value.str_ptr = NULL;
+	options[16].arg_value.str_ptr = NULL;
 	TEST_END();
 }
 
@@ -265,7 +265,7 @@ TEST_DEFINE(parse_options_long_string_list_test)
 	struct str_array strings;
 	str_array_init(&strings);
 
-	options[47].arg_value = &strings;
+	options[47].arg_value.str_array_ptr = &strings;
 
 	TEST_START() {
 		int argc = 5;
@@ -280,7 +280,7 @@ TEST_DEFINE(parse_options_long_string_list_test)
 		assert_string_eq("another string", str_array_get(&strings, 2));
 	}
 
-	options[47].arg_value = NULL;
+	options[47].arg_value.str_array_ptr = NULL;
 	str_array_release(&strings);
 
 	TEST_END();
@@ -292,10 +292,10 @@ TEST_DEFINE(parse_options_bool_test)
 	int bool_val_2 = 0;
 	int bool_val_3 = 0;
 	int bool_val_4 = 0;
-	options[1].arg_value = &bool_val_1;
-	options[2].arg_value = &bool_val_2;
-	options[10].arg_value = &bool_val_3;
-	options[23].arg_value = &bool_val_4;
+	options[1].arg_value.int_ptr = &bool_val_1;
+	options[2].arg_value.int_ptr = &bool_val_2;
+	options[10].arg_value.int_ptr = &bool_val_3;
+	options[23].arg_value.int_ptr = &bool_val_4;
 
 	TEST_START() {
 		const int argc = 3;
@@ -310,10 +310,10 @@ TEST_DEFINE(parse_options_bool_test)
 		assert_true(bool_val_4);
 	}
 
-	options[1].arg_value = NULL;
-	options[2].arg_value = NULL;
-	options[10].arg_value = NULL;
-	options[23].arg_value = NULL;
+	options[1].arg_value.int_ptr = NULL;
+	options[2].arg_value.int_ptr = NULL;
+	options[10].arg_value.int_ptr = NULL;
+	options[23].arg_value.int_ptr = NULL;
 	TEST_END();
 }
 
@@ -322,9 +322,9 @@ TEST_DEFINE(parse_options_int_test)
 	int bool_val_1 = 0;
 	int int_val_1 = 0;
 	int int_val_2 = 0;
-	options[1].arg_value = &bool_val_1;
-	options[22].arg_value = &int_val_1;
-	options[40].arg_value = &int_val_2;
+	options[1].arg_value.int_ptr = &bool_val_1;
+	options[22].arg_value.int_ptr = &int_val_1;
+	options[40].arg_value.int_ptr = &int_val_2;
 
 	TEST_START() {
 		const int argc = 4;
@@ -338,9 +338,9 @@ TEST_DEFINE(parse_options_int_test)
 		assert_eq(0xa1, int_val_2);
 	}
 
-	options[1].arg_value = NULL;
-	options[22].arg_value = NULL;
-	options[40].arg_value = NULL;
+	options[1].arg_value.int_ptr = NULL;
+	options[22].arg_value.int_ptr = NULL;
+	options[40].arg_value.int_ptr = NULL;
 	TEST_END();
 }
 
@@ -350,9 +350,9 @@ TEST_DEFINE(parse_options_string_test)
 	char *str_2 = NULL;
 
 	int bool_val_1 = 0;
-	options[1].arg_value = &bool_val_1;
-	options[3].arg_value = &str_1;
-	options[7].arg_value = &str_2;
+	options[1].arg_value.int_ptr = &bool_val_1;
+	options[3].arg_value.str_ptr = &str_1;
+	options[7].arg_value.str_ptr = &str_2;
 
 	TEST_START() {
 		const int argc = 4;
@@ -366,9 +366,9 @@ TEST_DEFINE(parse_options_string_test)
 		assert_string_eq("0xa1", str_2);
 	}
 
-	options[1].arg_value = NULL;
-	options[3].arg_value = NULL;
-	options[7].arg_value = NULL;
+	options[1].arg_value.int_ptr = NULL;
+	options[3].arg_value.str_ptr = NULL;
+	options[7].arg_value.str_ptr = NULL;
 
 	TEST_END();
 }
@@ -378,7 +378,7 @@ TEST_DEFINE(parse_options_string_list_test)
 	struct str_array strings;
 	str_array_init(&strings);
 
-	options[45].arg_value = &strings;
+	options[45].arg_value.str_array_ptr = &strings;
 
 	TEST_START() {
 		int argc = 5;
@@ -393,7 +393,7 @@ TEST_DEFINE(parse_options_string_list_test)
 		assert_string_eq("another string", str_array_get(&strings, 2));
 	}
 
-	options[45].arg_value = NULL;
+	options[45].arg_value.str_array_ptr = NULL;
 	str_array_release(&strings);
 
 	TEST_END();
@@ -403,8 +403,8 @@ TEST_DEFINE(parse_options_cmd_test)
 {
 	int bool_val_1 = 0;
 	int cmd_val_1 = 0;
-	options[1].arg_value = &bool_val_1;
-	options[43].arg_value = &cmd_val_1;
+	options[1].arg_value.int_ptr = &bool_val_1;
+	options[43].arg_value.int_ptr = &cmd_val_1;
 
 	TEST_START() {
 		int argc = 5;
@@ -430,7 +430,8 @@ TEST_DEFINE(parse_options_cmd_test)
 		assert_string_eq("another string", argv1[3]);
 	}
 
-	options[1].arg_value = NULL;
+	options[1].arg_value.int_ptr = NULL;
+	options[43].arg_value.int_ptr = NULL;
 
 	TEST_END();
 }
@@ -439,8 +440,8 @@ TEST_DEFINE(parse_options_skip_first_arg_test)
 {
 	int bool_val_1 = 0;
 	int bool_val_2 = 0;
-	options[15].arg_value = &bool_val_1;
-	options[35].arg_value = &bool_val_2;
+	options[15].arg_value.int_ptr = &bool_val_1;
+	options[35].arg_value.int_ptr = &bool_val_2;
 
 	TEST_START() {
 		const int argc = 2;
@@ -453,8 +454,8 @@ TEST_DEFINE(parse_options_skip_first_arg_test)
 		assert_true(bool_val_2);
 	}
 
-	options[15].arg_value = NULL;
-	options[35].arg_value = NULL;
+	options[15].arg_value.int_ptr = NULL;
+	options[35].arg_value.int_ptr = NULL;
 	TEST_END();
 }
 
@@ -464,9 +465,9 @@ TEST_DEFINE(parse_options_unknown_arg_test)
 	char *str_2 = NULL;
 
 	int bool_val_1 = 0;
-	options[1].arg_value = &bool_val_1;
-	options[3].arg_value = &str_1;
-	options[7].arg_value = &str_2;
+	options[1].arg_value.int_ptr = &bool_val_1;
+	options[3].arg_value.str_ptr = &str_1;
+	options[7].arg_value.str_ptr = &str_2;
 
 	TEST_START() {
 		const int argc = 4;
@@ -479,9 +480,9 @@ TEST_DEFINE(parse_options_unknown_arg_test)
 		assert_string_eq("my file", str_1);
 	}
 
-	options[1].arg_value = NULL;
-	options[3].arg_value = NULL;
-	options[7].arg_value = NULL;
+	options[1].arg_value.int_ptr = NULL;
+	options[3].arg_value.str_ptr = NULL;
+	options[7].arg_value.str_ptr = NULL;
 
 	TEST_END();
 }
@@ -491,11 +492,11 @@ TEST_DEFINE(parse_options_combined_short_arg_test)
 	int bool_val_1 = 0, bool_val_2 = 0, bool_val_3 = 0, bool_val_4 = 0;
 	char *string = NULL;
 
-	options[1].arg_value = &bool_val_1;
-	options[2].arg_value = &bool_val_2;
-	options[10].arg_value = &bool_val_3;
-	options[11].arg_value = &bool_val_4;
-	options[13].arg_value = &string;
+	options[1].arg_value.int_ptr = &bool_val_1;
+	options[2].arg_value.int_ptr = &bool_val_2;
+	options[10].arg_value.int_ptr = &bool_val_3;
+	options[11].arg_value.int_ptr = &bool_val_4;
+	options[13].arg_value.str_ptr = &string;
 
 	TEST_START() {
 		const int argc = 2;
@@ -512,11 +513,11 @@ TEST_DEFINE(parse_options_combined_short_arg_test)
 		assert_string_eq("test string", string);
 	}
 
-	options[1].arg_value = NULL;
-	options[2].arg_value = NULL;
-	options[10].arg_value = NULL;
-	options[11].arg_value = NULL;
-	options[13].arg_value = NULL;
+	options[1].arg_value.int_ptr = NULL;
+	options[2].arg_value.int_ptr = NULL;
+	options[10].arg_value.int_ptr = NULL;
+	options[11].arg_value.int_ptr = NULL;
+	options[13].arg_value.str_ptr = NULL;
 
 	TEST_END();
 }


### PR DESCRIPTION
To help avoid stack overflows when using the parse-options api, update
the command_option structure to include a union of different pointer
types instead of a single void pointer. When incorrect pointer types are
assigned, compiler warnings are generated.