### PR TITLE
import-key: filter expired/unusable keys

### DIFF
--- a/docs/git-chat-import-key.1
+++ b/docs/git-chat-import-key.1
@@ -7,8 +7,7 @@ git-chat-import-key \- import GnuPG public keys into a channel
 .SH SYNOPSIS
 .sp
 .nf
-\fIgit-chat-import-key\fR [\-\-gpg\-home <path>] [\-\-] <key fpr>...
-\fIgit-chat-import-key\fR (\-f | \-\-file) <path>
+\fIgit chat import-key [\-\-gpg\-home <path>] [((\-f | \-\-file) <path>)...] [\-\-] <key fpr>...
 \fIgit-chat-import-key\fR (\-h | \-\-help)
 
 
@@ -16,6 +15,8 @@ git-chat-import-key \- import GnuPG public keys into a channel
 To ensure that other users can include you as a recipient to messages sent in a particular channel, it might be necessary to import your GnuPG public key into that channel. In general, your GnuPG public keys should be imported if \fB.git-chat/keys\fR does not contain a file whose name is the fingerprint of your public key.
 
 When a key is imported into the channel, a new commit at the tip of the channel branch is created and must be published.
+
+Public keys can only be imported if they are valid and usable. Expired, revoked and disabled keys are filtered. Previously imported keys are ignored.
 
 
 .SH OPTIONS
@@ -34,6 +35,7 @@ Print a simple synopsis and exit.
 
 .SH SEE ALSO
 \fBgit-chat-channel\fR(1)
+\fBgit-chat-message\fR(1)
 
 
 .SH REPORTING BUGS

--- a/include/fs-utils.h
+++ b/include/fs-utils.h
@@ -71,7 +71,8 @@ int get_symlink_target(const char *symlink_path, struct strbuf *result, size_t s
 int get_cwd(struct strbuf *buff);
 
 /**
- * Create a new directory with the given base path and directory name.
+ * Create a new directory with the given base path and directory name, if no such
+ * directory exists.
  *
  * `base_path` and `dir` must be null terminated strings.
  *

--- a/include/gnupg/gpg-common.h
+++ b/include/gnupg/gpg-common.h
@@ -16,7 +16,7 @@ struct gpg_key_list {
 };
 
 struct gpg_key_list_node {
-	struct _gpgme_key *key;
+	gpgme_key_t key;
 	struct gpg_key_list_node *next;
 	struct gpg_key_list_node *prev;
 };

--- a/include/gnupg/key-filter.h
+++ b/include/gnupg/key-filter.h
@@ -16,7 +16,7 @@
  * Returns the number of keys (list nodes) filtered.
  * */
 int filter_gpg_keys_by_predicate(struct gpg_key_list *keys,
-		int (*predicate)(struct _gpgme_key *key, void *data), void *optional_data);
+		int (*predicate)(gpgme_key_t key, void *data), void *optional_data);
 
 /**
  * Predefined filter function which can be used to filter gpg keys that are either:
@@ -25,11 +25,11 @@ int filter_gpg_keys_by_predicate(struct gpg_key_list *keys,
  * - invalid,
  * - or cannot be used for encryption.
  * */
-int filter_gpg_unusable_keys(struct _gpgme_key *key, void *data);
+int filter_gpg_unusable_keys(gpgme_key_t key, void *data);
 
 /**
  * Predefined filter function used to filter secret keys from a key list.
  * */
-int filter_gpg_secret_keys(struct _gpgme_key *key, void *data);
+int filter_gpg_secret_keys(gpgme_key_t key, void *data);
 
 #endif //GIT_CHAT_KEY_FILTER_H

--- a/src/builtin/init.c
+++ b/src/builtin/init.c
@@ -62,7 +62,7 @@ static int init(const char *channel_name, const char *space_desc)
 	if (is_inside_git_chat_space())
 		DIE("a git-chat space cannot be reinitialized.");
 
-	LOG_INFO("Initializing new space '%s' with master channel name '%s'",
+	LOG_INFO("initializing new space '%s' with master channel name '%s'",
 			 space_desc, channel_name);
 
 	// execute 'git init' as child process
@@ -83,7 +83,7 @@ static int init(const char *channel_name, const char *space_desc)
 			 "Is your user configured through .gitconfig?");
 	}
 
-	LOG_DEBUG("Found user details (%s) from global .gitconfig", author.buff);
+	LOG_DEBUG("found user details (%s) from global .gitconfig", author.buff);
 
 	// create .git-chat dir
 	prepare_git_chat(channel_name, space_desc, author.buff);
@@ -158,7 +158,7 @@ static void prepare_git_chat(const char *channel_name, const char *description, 
 		FATAL("failed to obtain .git-chat dir");
 	copy_dir(templates_dir_path.buff, path.buff);
 
-	LOG_DEBUG("Copied directory from '%s' to '%s'", templates_dir_path.buff,
+	LOG_DEBUG("copied directory from '%s' to '%s'", templates_dir_path.buff,
 			  path.buff);
 
 	update_config(path.buff, channel_name, author);
@@ -170,7 +170,7 @@ static void prepare_git_chat(const char *channel_name, const char *description, 
 		FATAL("failed to obtain git-chat keys dir");
 	
 	safe_create_dir(path.buff, NULL, S_IRWXU | S_IRGRP | S_IROTH);
-	LOG_DEBUG("Created directory for gpg keys '%s'", path.buff);
+	LOG_DEBUG("created directory for gpg keys '%s'", path.buff);
 
 	// create chat cache directory
 	strbuf_clear(&path);
@@ -178,7 +178,7 @@ static void prepare_git_chat(const char *channel_name, const char *description, 
 		FATAL("failed to obtain chat cache dir");
 
 	safe_create_dir(path.buff, NULL, S_IRWXU | S_IRGRP | S_IROTH);
-	LOG_DEBUG("Created chat cache directory '%s'", path.buff);
+	LOG_DEBUG("created chat cache directory '%s'", path.buff);
 
 	strbuf_release(&path);
 	strbuf_release(&templates_dir_path);
@@ -221,7 +221,7 @@ static void update_config(char *base, const char *channel_name, const char *auth
 	strbuf_release(&config_path);
 	config_data_release(&conf);
 
-	LOG_INFO("Updated master channel configuration");
+	LOG_INFO("updated master channel configuration");
 }
 
 /**
@@ -250,7 +250,7 @@ static void update_space_description(char *base, const char *description)
 	close(desc_fd);
 	strbuf_release(&desc_path);
 
-	LOG_INFO("Updated space description to '%s'", description);
+	LOG_INFO("updated space description to '%s'", description);
 }
 
 /**
@@ -295,5 +295,5 @@ static void initialize_channel_root()
 	if (ret)
 		DIE("failed to commit index to the tree; git exited with status %d", ret);
 
-	LOG_DEBUG("Successfully created channel root commit");
+	LOG_DEBUG("successfully created channel root commit");
 }

--- a/src/builtin/message.c
+++ b/src/builtin/message.c
@@ -229,7 +229,7 @@ static void read_message_from_file(const char *file_path, struct strbuf *buff)
  * - no recipients match any subkey comment field
  * - no recipients match any subkey address field
  * */
-static int filter_gpg_keylist_by_recipients(struct _gpgme_key *key, void *data)
+static int filter_gpg_keylist_by_recipients(gpgme_key_t key, void *data)
 {
 	struct str_array *recipients = (struct str_array *)data;
 
@@ -288,7 +288,7 @@ static int encrypt_message_asym(struct gc_gpgme_ctx *ctx, struct str_array *reci
 
 		// if there is not a 1-1 mapping of recipients to gpg keys, fail
 		if ((size_t)key_count != recipients->len) {
-			LOG_ERROR("Some recipients defined cannot be mapped to GPG keys");
+			LOG_ERROR("some recipients defined cannot be mapped to GPG keys");
 
 			release_gpg_key_list(&gpg_keys);
 			return -1;

--- a/src/fs-utils.c
+++ b/src/fs-utils.c
@@ -101,7 +101,7 @@ ssize_t copy_file(const char *dest, const char *src, mode_t mode)
 	close(in_fd);
 	close(out_fd);
 
-	LOG_TRACE("File copied from '%s' to '%s'", src, dest);
+	LOG_TRACE("file copied from '%s' to '%s'", src, dest);
 
 	return bytes_written;
 }
@@ -178,9 +178,9 @@ void safe_create_dir(const char *base_path, char *dir, unsigned int mode)
 			FATAL("unable to create directory '%s'", buff.buff);
 
 		errno = errsv;
-		LOG_WARN("Directory '%s' already exists", buff.buff);
+		LOG_WARN("directory '%s' already exists", buff.buff);
 	} else {
-		LOG_TRACE("Created new directory '%s'", buff.buff);
+		LOG_TRACE("created new directory '%s'", buff.buff);
 	}
 
 	strbuf_release(&buff);

--- a/src/gnupg/decryption.c
+++ b/src/gnupg/decryption.c
@@ -22,7 +22,7 @@ int decrypt_asymmetric_message(struct gc_gpgme_ctx *ctx,
 	// if decryption failed, we won't die FATAL, we will just notify the caller
 	err = gpgme_op_decrypt(ctx->gpgme_ctx, message_in, message_out);
 	if (err) {
-		LOG_WARN("GPG decryption failed unexpectedly: %d %s\n",
+		LOG_WARN("gpg decryption failed unexpectedly: %d %s\n",
 				gpgme_err_code(err), gpgme_strerror(err));
 
 		ret = gpgme_err_code(err) == GPG_ERR_NO_DATA ? 1 : -1;

--- a/src/gnupg/encryption.c
+++ b/src/gnupg/encryption.c
@@ -11,7 +11,7 @@ void asymmetric_encrypt_plaintext_message(struct gc_gpgme_ctx *ctx,
 	gpgme_error_t err;
 	int errsv = errno;
 
-	LOG_INFO("Encrypting plaintext message");
+	LOG_INFO("encrypting plaintext message");
 
 	struct str_array keys;
 	str_array_init(&keys);
@@ -22,13 +22,13 @@ void asymmetric_encrypt_plaintext_message(struct gc_gpgme_ctx *ctx,
 		struct str_array_entry *entry = str_array_insert_nodup(&keys, NULL, keys.len);
 		entry->data = node->key;
 
-		LOG_TRACE("Recipient gpg key fingerprint: %s", node->key->fpr);
+		LOG_TRACE("recipient gpg key fingerprint: %s", node->key->fpr);
 
 		node = node->next;
 	}
 
 	size_t keys_len = 0;
-	struct _gpgme_key **keys_array = (struct _gpgme_key **)str_array_detach_data(&keys, &keys_len);
+	gpgme_key_t *keys_array = (gpgme_key_t *)str_array_detach_data(&keys, &keys_len);
 	if (!keys_len)
 		BUG("no gpg keys given to asymmetric_encrypt_plaintext_message()");
 
@@ -84,6 +84,6 @@ void asymmetric_encrypt_plaintext_message(struct gc_gpgme_ctx *ctx,
 	gpgme_data_release(message_in);
 	gpgme_data_release(message_out);
 
-	LOG_INFO("Successfully encrypted message");
+	LOG_INFO("successfully encrypted message");
 	errno = errsv;
 }

--- a/src/gnupg/gpg-common.c
+++ b/src/gnupg/gpg-common.c
@@ -25,10 +25,10 @@ void init_gpgme_openpgp_engine(void)
 	gpgme_error_t err;
 	int errsv = errno;
 
-	LOG_INFO("Initializing GPGME with GPGME_PROTOCOL_OpenPGP engine");
+	LOG_INFO("initializing GPGME with GPGME_PROTOCOL_OpenPGP engine");
 
 	const char *version = gpgme_check_version(NULL);
-	LOG_INFO("Using installed GPGME version %s", version);
+	LOG_INFO("using installed GPGME version %s", version);
 
 	setlocale(LC_ALL, "");
 	err = gpgme_set_locale(NULL, LC_CTYPE, setlocale(LC_CTYPE, NULL));

--- a/src/gnupg/key-filter.c
+++ b/src/gnupg/key-filter.c
@@ -3,7 +3,7 @@
 #include "gnupg/gpg-common.h"
 
 int filter_gpg_keys_by_predicate(struct gpg_key_list *keys,
-		int (*predicate)(struct _gpgme_key *, void *), void *optional_data)
+		int (*predicate)(gpgme_key_t, void *), void *optional_data)
 {
 	int filtered_keys = 0;
 	struct gpg_key_list_node *node = keys->head;
@@ -35,7 +35,7 @@ int filter_gpg_keys_by_predicate(struct gpg_key_list *keys,
 	return filtered_keys;
 }
 
-int filter_gpg_unusable_keys(struct _gpgme_key *key, void *data)
+int filter_gpg_unusable_keys(gpgme_key_t key, void *data)
 {
 	// Unused
 	(void) data;
@@ -46,6 +46,8 @@ int filter_gpg_unusable_keys(struct _gpgme_key *key, void *data)
 		return 0;
 	if (key->invalid)
 		return 0;
+	if (key->revoked)
+		return 0;
 
 	if (!key->can_encrypt)
 		return 0;
@@ -53,7 +55,7 @@ int filter_gpg_unusable_keys(struct _gpgme_key *key, void *data)
 	return 1;
 }
 
-int filter_gpg_secret_keys(struct _gpgme_key *key, void *data)
+int filter_gpg_secret_keys(gpgme_key_t key, void *data)
 {
 	// Unused
 	(void) data;

--- a/src/working-tree.c
+++ b/src/working-tree.c
@@ -18,13 +18,13 @@ int is_inside_git_chat_space()
 
 	struct stat sb;
 	if (stat(GIT_CHAT_DIR, &sb) == -1 || !S_ISDIR(sb.st_mode)) {
-		LOG_DEBUG("Cannot stat .git-chat directory; %s", strerror(errno));
+		LOG_DEBUG("cannot stat .git-chat directory; %s", strerror(errno));
 		errno = errsv;
 		return 0;
 	}
 
 	if (stat(".git", &sb) == -1 || !S_ISDIR(sb.st_mode)) {
-		LOG_DEBUG("Cannot stat .git directory; %s", strerror(errno));
+		LOG_DEBUG("cannot stat .git directory; %s", strerror(errno));
 		errno = errsv;
 		return 0;
 	}

--- a/test/integration/t004-git-chat-import-key.sh
+++ b/test/integration/t004-git-chat-import-key.sh
@@ -35,18 +35,16 @@ assert_success 'git-chat import-key should correctly import key from file' '
 	GNUPGHOME="$(pwd)/.git/.gnupg" gpg --list-keys 41C4155B702593BFF6D7D140AB4F26E5A765DFDC
 '
 
-assert_success 'git-chat import-key should fail when given file paths and fingerprints' '
+assert_success 'git-chat import-key should support import from keys and fingerprints' '
 	reset_trash_dir &&
 	git chat init &&
 	setup_test_gpg &&
 	gpg --import $TEST_RESOURCES_DIR/gpgkeys/*.pub.gpg
 ' '
-	! git chat import-key -f $TEST_RESOURCES_DIR/gpgkeys/ajones_noexpire.pub.gpg 41C4155B702593BFF6D7D140AB4F26E5A765DFDC 2>err &&
-	grep "mutually exclusive operations" err &&
-	git chat import-key 41C4155B702593BFF6D7D140AB4F26E5A765DFDC --file $TEST_RESOURCES_DIR/gpgkeys/ajones_noexpire.pub.gpg 2>err >out &&
-	grep "could not find public gpg key with fingerprint" err &&
-	grep "41C4155B702593BFF6D7D140AB4F26E5A765DFDC" out &&
-	GNUPGHOME="$(pwd)/.git/.gnupg" gpg --list-keys 41C4155B702593BFF6D7D140AB4F26E5A765DFDC
+	git chat import-key -f $TEST_RESOURCES_DIR/gpgkeys/ajones_noexpire.pub.gpg 41C4155B702593BFF6D7D140AB4F26E5A765DFDC &&
+	git show -s --format=%B >commit_msg &&
+	grep "49A9FED4003D28CB5D8CF96748F6785D011F494B" commit_msg &&
+	grep "41C4155B702593BFF6D7D140AB4F26E5A765DFDC" commit_msg
 '
 
 assert_success 'git-chat import-key should fail if key is already imported' '


### PR DESCRIPTION
The import-key builtin was rewritten from the ground up to be more
robust and usable. In this revision, keys can be imported from files and
from keyrings at the same time, where this was not possible before.
Improvements were made to show descriptive warning and logging messages
to indicate when keys are filtered.

Keys are filtered when unusable (notably, expired). A warning message is
shown to the user.

The commit message body was updated to include imported key fingerprints.