### PR TITLE
introduce .trusted-keys

### DIFF
--- a/docs/git-chat-channel.1
+++ b/docs/git-chat-channel.1
@@ -13,10 +13,12 @@ git-chat-channel \- create, switch to, list and remove channels
 \fIgit-chat-channel\fR (list | ls) [(\-a | \-\-all)]
 \fIgit-chat-channel\fR [<subcommand>] [(\-h | \-\-help)]
 
+
 .SH DESCRIPTION
 Interact with local channels (branches).
 
 This command can be used to create new channels, list local and remote channels, switch to another channel, and delete channels.
+
 
 .SH COMMANDS
 .TP
@@ -34,6 +36,7 @@ Delete a local channel with ref \fB<ref>\fR.
 .TP
 list, ls
 List all local or remote channels. By default, any remote channels that are up to date with a local channel are filtered, unless the \fI--all\fR option is supplied.
+
 
 .SH OPTIONS
 .TP

--- a/docs/git-chat-config.1
+++ b/docs/git-chat-config.1
@@ -3,6 +3,7 @@
 .SH NAME
 git-chat-config \- configure the current channel
 
+
 .SH SYNOPSIS
 .sp
 .nf
@@ -222,6 +223,7 @@ When a section name or property name must contain symbols, the section name or p
 .PP
 
 Double quotes (`"`) and backslashes (`\\`) can be escaped as `\\"` and `\\\\`, respectively. Backslashes preceding other characters are simply removed, so `\\n` becomes `n`.
+
 
 .SH SEE ALSO
 \fBgit-chat-init\fR(1)

--- a/docs/git-chat-init.1
+++ b/docs/git-chat-init.1
@@ -3,6 +3,7 @@
 .SH NAME
 git-chat-init \- initialize a git-chat messaging space
 
+
 .SH SYNOPSIS
 .sp
 .nf

--- a/docs/git-chat-message.1
+++ b/docs/git-chat-message.1
@@ -3,6 +3,7 @@
 .SH NAME
 git-chat-message \- encrypt plaintext messages and commit them to the git history
 
+
 .SH SYNOPSIS
 .sp
 .nf
@@ -28,7 +29,9 @@ $ git show --format="%B" HEAD | gpg --decrypt
 
 If the message, or a file containing the message, is not provided as a command line argument, the \fBvim\fR editor is invoked so that the user can compose the message. Multiple \fI-m\fR or \fI-f\fR are not supported at this time.
 
-Messages may only be decrypted by message recipients given either implicitly or with the \fI--recipient\fR option. Each recipient, including the user who authored the message, must export their public key in ASCII-armored format into a file in the \fI.keys\fR directory within the git-chat space (see \fIgit-chat-import-key\fR). By default, messages are encrypted with all public keys in the \fI.keys\fR directory if no recipients are explicitly defined.
+Messages may only be decrypted by message recipients given either implicitly or with the \fI--recipient\fR option. Each recipient, including the user who authored the message, must export their public key in ASCII-armored format into a file in the \fI.keys\fR directory within the git-chat space (see \fIgit-chat-import-key(1)\fR). By default, messages are encrypted with all public keys in the \fI.keys\fR directory if no recipients are explicitly defined.
+
+To protect against accidental communication of sensitive messages to untrusted parties, users may opt to maintain a trust list. If a file \fI.git/.trusted-keys\fR exists, each line is treated as a trusted GPG key fingerprint. Only trusted recipients will be included in new messages. Users should include their own key fingerprints in the trust list, otherwise they may not be able to decrypt their own messages.
 
 \fIgit-chat\fR manages an internal gpg keyring and trust store which is intentionally kept separate from the user's gpg home directory. The internal gpg home directory is located within the \fI.git\fR directory under \fI.git/.gnupg\fR. It is ill advised to manipulate the git-chat gpg home directory manually.
 
@@ -67,6 +70,7 @@ When composing new messages in the editor, decrypt and show the last <n> message
 .TP
 \-h, \-\-help
 Print a simple synopsis and exit.
+
 
 .SH SEE ALSO
 \fBgit-chat-init\fR(1)

--- a/docs/git-chat.1
+++ b/docs/git-chat.1
@@ -3,6 +3,7 @@
 .SH NAME
 git-chat \- use a Git repository as a chatroom
 
+
 .SH SYNOPSIS
 .sp
 .nf
@@ -82,6 +83,7 @@ Display and format messages in a channel.
 .SH FILE/DIRECTORY LAYOUT
 @DOCS_FILE_DIRECTORY_LAYOUT_SECTION@
 
+
 .SH CONFIGURATION
 The config file has a format similar to INI or TOML, but simplified. It consists of key-value pairs, organized in sections.
 
@@ -133,6 +135,7 @@ NONE
 .TP
 \fBGIT_CHAT_PAGER\fR, \fBGIT_PAGER\fR, \fBPAGER\fR
 When output is being paged (\fIgit-chat-read\fR, for example), these environment variables may be used to specify an alternate paging program. The variable value must be the absolute path to the executable (e.g. /usr/bin/cat).
+
 
 .SH EXTENDING GIT-CHAT
 \fIgit-chat\fR follows a similar extension model to Git, where executables located on the PATH that are prefixed with \fBgit-chat-\fR will be invoked when \fBgit chat <extension name>\fR is run at the command line. This allows you to build custom plugins in your language of choice.

--- a/docs/sections/directory-structure.section
+++ b/docs/sections/directory-structure.section
@@ -1,4 +1,4 @@
-\fIgit-chat\fR uses a rather simple directory structure. When a repository is initialized, three directories are created at the root of the working tree: \fB.git\fR, \fB.git-chat\fR, and \fB.keys\fR.
+\fIgit-chat\fR uses a rather simple directory structure. When a repository is initialized, two directories are created at the root of the working tree: \fB.git\fR abd \fB.git-chat\fR.
 
 .TP
 .B .git
@@ -6,4 +6,22 @@ This directory is created by \fIgit-init\fR, and is largely untouched by git-cha
 
 .TP
 .B .git-chat
-This directory is created by \fIgit-chat-init\fR. It contains channel metadata, such as the channel name and description. Exported GPG keys are located under \fB.git-chat/keys\fR. These files are tracked, and are therefore public to all users.
+This directory is created by \fIgit-chat-init\fR. It contains channel metadata, such as the channel name and description. Channel GPG keys are located under \fB.git-chat/keys\fR. These files are tracked, and are therefore public to all users.
+
+.TP
+.B .git/.trusted-keys
+Optional file containing trusted GPG key fingerprints. To protect against accidental communication of sensitive messages to untrusted parties, users may opt to maintain this list of trusted GPG key fingerprints. If the file exists, each line is treated as a trusted GPG key fingerprint. Only trusted recipients will be included in new messages.
+
+When managing a trusted keys list, it's important to include your GPG fingerprint as well, otherwise you will not be able to decrypt your own messages.
+
+.TP
+.B .git-chat/keys
+GPG public key files for all members of the current channel.
+
+.TP
+.B .git-chat/config
+Channel configuration file.
+
+.TP
+.B .git-chat/description
+Generic description file for this git\-chat space.

--- a/include/argv-array.h
+++ b/include/argv-array.h
@@ -1,7 +1,7 @@
 #ifndef GIT_CHAT_ARGV_ARRAY_H
 #define GIT_CHAT_ARGV_ARRAY_H
 
-#include <stddef.h>
+#include <sys/types.h>
 
 #include "str-array.h"
 

--- a/include/fs-utils.h
+++ b/include/fs-utils.h
@@ -1,7 +1,7 @@
 #ifndef GIT_CHAT_FS_UTILS_H
 #define GIT_CHAT_FS_UTILS_H
 
-#include <stddef.h>
+#include <sys/types.h>
 
 #include "strbuf.h"
 

--- a/include/git/commit.h
+++ b/include/git/commit.h
@@ -1,6 +1,9 @@
 #ifndef GIT_CHAT_COMMIT_H
 #define GIT_CHAT_COMMIT_H
 
+#include <inttypes.h>
+
+#include "strbuf.h"
 #include "git/git.h"
 
 struct git_time {

--- a/include/git/git.h
+++ b/include/git/git.h
@@ -1,8 +1,6 @@
 #ifndef GIT_CHAT_GIT_H
 #define GIT_CHAT_GIT_H
 
-#include <inttypes.h>
-
 #include "str-array.h"
 #include "strbuf.h"
 

--- a/include/gnupg/gpg-common.h
+++ b/include/gnupg/gpg-common.h
@@ -4,6 +4,7 @@
 #include <gpgme.h>
 
 #include "strbuf.h"
+#include "utils.h"
 
 struct gc_gpgme_ctx {
 	struct gpgme_context *gpgme_ctx;
@@ -20,12 +21,6 @@ struct gpg_key_list_node {
 	struct gpg_key_list_node *next;
 	struct gpg_key_list_node *prev;
 };
-
-#include "key-manager.h"
-#include "key-filter.h"
-#include "encryption.h"
-#include "decryption.h"
-#include "utils.h"
 
 /**
  * Retrieve a statically-allocated string representing the version of the gpgme

--- a/include/gnupg/key-filter.h
+++ b/include/gnupg/key-filter.h
@@ -32,4 +32,10 @@ int filter_gpg_unusable_keys(gpgme_key_t key, void *data);
  * */
 int filter_gpg_secret_keys(gpgme_key_t key, void *data);
 
+/**
+ * Predefined filter function used to filter keys by fingerprints. The void pointer
+ * `data` is treated as a pointer to a str_array of fingerprints.
+ * */
+int filter_gpg_keys_by_fingerprint(gpgme_key_t key, void *data);
+
 #endif //GIT_CHAT_KEY_FILTER_H

--- a/include/gnupg/key-manager.h
+++ b/include/gnupg/key-manager.h
@@ -2,6 +2,7 @@
 #define GIT_CHAT_KEY_MANAGER_H
 
 #include "gnupg/gpg-common.h"
+#include "str-array.h"
 
 /**
  * Import an ASCII-armored gpg key from a file into the configured gpg keyring.

--- a/include/gnupg/key-trust.h
+++ b/include/gnupg/key-trust.h
@@ -1,0 +1,17 @@
+#ifndef GIT_CHAT_INCLUDE_GNUPG_KEY_TRUST_H
+#define GIT_CHAT_INCLUDE_GNUPG_KEY_TRUST_H
+
+#include <sys/types.h>
+
+#include "str-array.h"
+
+/**
+ * Read the `.trusted-keys` file under `.git/` and append trusted fingerprints
+ * to the given `trusted_keys` str_array.
+ *
+ * Returns the number of fingerprints read from the trusted-keys file, or -1
+ * if the file does not exist or could not be read for some reason.
+ * */
+ssize_t read_trust_list(struct str_array *trusted_keys);
+
+#endif //GIT_CHAT_INCLUDE_GNUPG_KEY_TRUST_H

--- a/include/parse-options.h
+++ b/include/parse-options.h
@@ -1,8 +1,10 @@
 #ifndef GIT_CHAT_PARSE_OPTIONS_H
 #define GIT_CHAT_PARSE_OPTIONS_H
 
-#include <stddef.h>
 #include <stdarg.h>
+#include <stddef.h>
+
+#include "str-array.h"
 
 /**
  * parse-options api

--- a/include/run-command.h
+++ b/include/run-command.h
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 
 #include "argv-array.h"
+#include "str-array.h"
 #include "strbuf.h"
 
 /**

--- a/include/str-array.h
+++ b/include/str-array.h
@@ -1,7 +1,7 @@
 #ifndef GIT_CHAT_STR_ARRAY_H
 #define GIT_CHAT_STR_ARRAY_H
 
-#include <stddef.h>
+#include <sys/types.h>
 #include <stdarg.h>
 
 /**
@@ -140,7 +140,8 @@ int str_array_vpush(struct str_array *str_a, va_list args);
  * This function returns a pointer to the str_array_entry, which can be used to
  * set the `data` member.
  * */
-struct str_array_entry *str_array_insert(struct str_array *str_a, const char *str, size_t pos);
+struct str_array_entry *str_array_insert(struct str_array *str_a,
+		const char *str, size_t pos);
 
 /**
  * Insert a string into a given position in the str_array. The string is not
@@ -160,7 +161,8 @@ struct str_array_entry *str_array_insert(struct str_array *str_a, const char *st
  * This function returns a pointer to the str_array_entry, which can be used to
  * set the `data` member.
  * */
-struct str_array_entry *str_array_insert_nodup(struct str_array *str_a, char *str, size_t pos);
+struct str_array_entry *str_array_insert_nodup(struct str_array *str_a,
+		char *str, size_t pos);
 
 /**
  * Sort all entries in the str_array in 'strcmp()' order.
@@ -206,7 +208,8 @@ void str_array_delete(struct str_array *str_a, size_t pos, size_t n);
  *
  * Returns zero if the entry was removed successfully. Otherwise, returns non-zero.
  * */
-int str_array_remove_entry(struct str_array *str_a, size_t pos, struct str_array_entry *entry);
+int str_array_remove_entry(struct str_array *str_a, size_t pos,
+		struct str_array_entry *entry);
 
 /**
  * Remove all strings for the str_array.

--- a/include/strbuf.h
+++ b/include/strbuf.h
@@ -1,7 +1,8 @@
 #ifndef GIT_CHAT_STRBUF_H
 #define GIT_CHAT_STRBUF_H
 
-#include <stddef.h>
+#include <sys/types.h>
+#include <stdarg.h>
 
 #include "str-array.h"
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -2,6 +2,7 @@
 #define GIT_CHAT_UTILS_H
 
 #include <sys/types.h>
+
 #include "logging.h"
 
 #define NORETURN __attribute__((noreturn))

--- a/src/builtin/channel-list.c
+++ b/src/builtin/channel-list.c
@@ -32,6 +32,10 @@ struct channel_details {
 	unsigned current: 1;
 };
 
+/**
+ * Initialize a channel details structure. Must be released with
+ * `channel_details_release` after use.
+ * */
 static void channel_details_init(struct channel_details *channel,
 		struct git_oid *oid, unsigned is_remote, unsigned is_current)
 {
@@ -47,6 +51,9 @@ static void channel_details_init(struct channel_details *channel,
 	channel->origin = NULL;
 }
 
+/**
+ * Release a channel details structure.
+ * */
 static void channel_details_release(struct channel_details *channel)
 {
 	memset(channel->object_id.id, 0, GIT_RAW_OBJECT_ID);
@@ -361,11 +368,19 @@ fail:
 	return status;
 }
 
+/**
+ * Fetch all channels with the refname pattern `refs/heads`. Refer to
+ * `fetch_channels` implementation for further details.
+ * */
 static int fetch_local_channels(struct str_array *channel_refs)
 {
 	return fetch_channels(channel_refs, "refs/heads", 0);
 }
 
+/**
+ * Fetch all channels with the refname pattern `refs/remotes`. Refer to
+ * `fetch_channels` implementation for further details.
+ * */
 static int fetch_remote_channels(struct str_array *channel_refs)
 {
 	return fetch_channels(channel_refs, "refs/remotes", 1);
@@ -425,6 +440,10 @@ struct table_dimensions {
 	int channel_name;
 };
 
+/**
+ * Calculate the width (in characters) for each column. Needed when displaying
+ * channels in a tablulated format.
+ * */
 static void calculate_table_dimensions(struct str_array *channels,
 		struct table_dimensions *dims)
 {

--- a/src/builtin/get.c
+++ b/src/builtin/get.c
@@ -1,4 +1,3 @@
-#include <stdio.h>
 #include "parse-options.h"
 
 static const struct usage_string get_cmd_usage[] = {

--- a/src/builtin/read.c
+++ b/src/builtin/read.c
@@ -2,6 +2,7 @@
 
 #include "git/graph-traversal.h"
 #include "gnupg/gpg-common.h"
+#include "gnupg/decryption.h"
 #include "working-tree.h"
 #include "parse-options.h"
 #include "paging.h"
@@ -18,6 +19,12 @@ struct graph_traversal_context {
 	struct gc_gpgme_ctx *gpg_ctx;
 };
 
+/**
+ * Commit traversal callback that attempts to decrypt the commit message body
+ * and pretty-prints the message to standard output.
+ *
+ * Returns zero.
+ * */
 static int commit_traversal_cb(struct git_commit *commit, void *data)
 {
 	struct graph_traversal_context *ctx = (struct graph_traversal_context *) data;
@@ -47,6 +54,13 @@ static int commit_traversal_cb(struct git_commit *commit, void *data)
 	return 0;
 }
 
+/**
+ * Read messages in the configured pager, starting at the given `commit`. If
+ * limit is a positive integer, at most `limit` messages are shown. If `no_color`
+ * is non-zero, ANSI color escape sequences are not written to output.
+ *
+ * Returns zero.
+ * */
 static int read_messages(const char *commit, int limit, int no_color)
 {
 	struct gc_gpgme_ctx gpg_ctx;

--- a/src/git/git.c
+++ b/src/git/git.c
@@ -1,3 +1,4 @@
+#include <stddef.h>
 #include <ctype.h>
 
 #include "git/git.h"

--- a/src/git/index.c
+++ b/src/git/index.c
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 #include "git/index.h"
 #include "run-command.h"
 

--- a/src/gnupg/key-filter.c
+++ b/src/gnupg/key-filter.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <string.h>
 
 #include "gnupg/gpg-common.h"
 
@@ -61,4 +62,16 @@ int filter_gpg_secret_keys(gpgme_key_t key, void *data)
 	(void) data;
 
 	return !key->secret;
+}
+
+int filter_gpg_keys_by_fingerprint(gpgme_key_t key, void *data)
+{
+	struct str_array *fingerprints = (struct str_array *) data;
+
+	for (size_t fpr_index = 0; fpr_index < fingerprints->len; fpr_index++) {
+		if (!strcmp(key->fpr, str_array_get(fingerprints, fpr_index)))
+			return 1;
+	}
+
+	return 0;
 }

--- a/src/gnupg/key-trust.c
+++ b/src/gnupg/key-trust.c
@@ -1,0 +1,47 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+
+#include "gnupg/key-trust.h"
+#include "strbuf.h"
+#include "fs-utils.h"
+#include "utils.h"
+
+ssize_t read_trust_list(struct str_array *trusted_keys)
+{
+	struct strbuf trusted_keys_file_path;
+	strbuf_init(&trusted_keys_file_path);
+
+	if (get_cwd(&trusted_keys_file_path))
+		FATAL("unable to obtain the current working directory from getcwd()");
+
+	strbuf_attach_str(&trusted_keys_file_path, "/.git/.trusted-keys");
+
+	int fd = open(trusted_keys_file_path.buff, O_RDONLY);
+	strbuf_release(&trusted_keys_file_path);
+
+	if (fd < 0)
+		return -1;
+
+	struct strbuf file_contents;
+	struct str_array fingerprints;
+
+	strbuf_init(&file_contents);
+	str_array_init(&fingerprints);
+
+	strbuf_attach_fd(&file_contents, fd);
+	close(fd);
+
+	size_t line_count = strbuf_split(&file_contents, "\n", &fingerprints);
+	strbuf_release(&file_contents);
+
+	for (size_t i = 0; i < fingerprints.len; i++) {
+		const char *fpr = str_array_get(&fingerprints, i);
+		if (strlen(fpr))
+			str_array_push(trusted_keys, fpr, NULL);
+	}
+
+	str_array_release(&fingerprints);
+
+	return (ssize_t) line_count;
+}


### PR DESCRIPTION
Anyone can add GPG keys to a git-chat space, including untrusted keys.
If someone added a public key to a git-chat space for a third party that
isn't trusted, that third party might be able to read messages
(git-chat-message includes all recipients by default).

Regularly checking to see if new keys were added, and looking through
them carefully, before writing each message can be annoying. Even more
annoying is typing a (trusted) list of recipients at the command line
whenever you write a message.

Under this revision, add support for reading from a .trusted-keys file to
filter message recipients. Users can add fingerprints that they trust
to this file, and only those keys will be used when composing messages.

The documentation was updated to reflect this. Various minor
improvements were made as well.