### PR TITLE
chore(build): modernize build infrastructure

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,14 +33,14 @@ jobs:
         run: make -C ${{github.workspace}}/build integration
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: integration-out
           path: ${{github.workspace}}/build/test/out.log
           retention-days: 1
       - name: Upload Binaries
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ success() }}
         with:
           name: Debian Package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,29 @@
-cmake_policy(SET CMP0048 NEW)
-project(git-chat VERSION 0.0.1 DESCRIPTION "A Git-Based Command-Line Messaging Application" LANGUAGES C)
+# Initialize Build Environment
+cmake_minimum_required(VERSION 3.18.4)
 
-cmake_minimum_required(VERSION 3.7.2)
 set(CMAKE_C_STANDARD 11)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+project(git-chat
+	DESCRIPTION "A Git-Based Command-Line Messaging Application"
+	HOMEPAGE_URL "https://github.com/brandon1024/gitchat"
+	LANGUAGES C
+	VERSION 0.0.1
+)
 
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-	set(CMAKE_INSTALL_PREFIX $ENV{HOME}/ CACHE PATH "Install prefix default" FORCE)
-endif (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+include(GNUInstallDirs)
 
-if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-	add_definitions(-Wall -Werror -pedantic)
-elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
-	add_definitions(-Wall -Wextra -pedantic)
-endif ()
+set(CMAKE_C_FLAGS "-Wall -Werror -pedantic")
+set(CMAKE_C_FLAGS_DEBUG "-g -ggdb")
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/")
 
-#
-# Configure Project
-#
+# Configure Build Options
+option(RUNTIME_LOGGING "Compile with logging enabled" ON)
+
+# Read Version Information
 execute_process(
 		COMMAND git rev-parse --short HEAD
-		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 		OUTPUT_VARIABLE GIT_CHAT_GIT_REV
 		OUTPUT_STRIP_TRAILING_WHITESPACE
 		RESULT_VARIABLE git_rev_parse_ret
@@ -32,53 +33,49 @@ if (NOT git_rev_parse_ret EQUAL "0")
 	set(GIT_CHAT_GIT_REV "unknown-rev")
 endif ()
 
-if (NOT CMAKE_BUILD_TYPE MATCHES RELEASE)
-	set(GIT_CHAT_VERSION "${CMAKE_PROJECT_VERSION}.git-${GIT_CHAT_GIT_REV}")
-else ()
-	set(GIT_CHAT_VERSION ${CMAKE_PROJECT_VERSION})
-endif (NOT CMAKE_BUILD_TYPE MATCHES RELEASE)
-
-option(RUNTIME_LOGGING "Compile with logging enabled" ON)
-if (RUNTIME_LOGGING)
-	add_definitions(-DRUNTIME_LOGGING)
-endif (RUNTIME_LOGGING)
+set(GIT_CHAT_VERSION "${CMAKE_PROJECT_VERSION}.git-${GIT_CHAT_GIT_REV}")
 
 configure_file(
-	"${PROJECT_SOURCE_DIR}/templates/version.h.in"
-	"${PROJECT_BINARY_DIR}/include/version.h"
+	"${CMAKE_CURRENT_SOURCE_DIR}/templates/version.h.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/include/version.h"
 )
 
-
-#
-# Configure git-chat Executable and Installation
-#
+# Load Project Dependencies
 find_package(GPGME REQUIRED)
-if (NOT GPGME_VANILLA_FOUND)
-	message(FATAL_ERROR "Failed to locate GPGME dependency (GPGME_VANILLA)")
-endif ()
+
+# Configure Build Targets
+set(GITCHAT_BUILD_DEFINITIONS
+	$<$<BOOL:${RUNTIME_LOGGING}>:RUNTIME_LOGGING>
+	$<$<CONFIG:Debug>:DEBUGGING_ENABLED>
+)
 
 file(GLOB_RECURSE src_list ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)
 list(REMOVE_ITEM src_list ${CMAKE_CURRENT_SOURCE_DIR}/src/git-chat.c)
 
 # build static library so that tests don't have to compile sources twice
 add_library(git-chat-internal STATIC ${src_list})
-target_link_libraries(git-chat-internal m ${GPGME_VANILLA_LIBRARIES})
+target_compile_definitions(git-chat-internal PUBLIC ${GITCHAT_BUILD_DEFINITIONS})
+target_link_libraries(git-chat-internal m GPGME::libgpgme)
 target_include_directories(git-chat-internal PRIVATE
 		"${CMAKE_CURRENT_SOURCE_DIR}/include/"
 		"${CMAKE_CURRENT_BINARY_DIR}/include/"
-		"${GPGME_INCLUDES}"
 )
 
 add_executable(git-chat ${CMAKE_CURRENT_SOURCE_DIR}/src/git-chat.c)
+target_compile_definitions(git-chat-internal PUBLIC ${GITCHAT_BUILD_DEFINITIONS})
 target_link_libraries(git-chat git-chat-internal)
 target_include_directories(git-chat PRIVATE
 		"${CMAKE_CURRENT_SOURCE_DIR}/include/"
 		"${CMAKE_CURRENT_BINARY_DIR}/include/"
-		"${GPGME_INCLUDES}"
 )
 
-install(TARGETS git-chat RUNTIME DESTINATION bin)
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/share/ DESTINATION share/git-chat)
+# Configure Install Targets
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set_property(CACHE CMAKE_INSTALL_PREFIX PROPERTY VALUE "$ENV{HOME}/")
+endif()
+
+install(TARGETS git-chat RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/share/ DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/git-chat)
 
 #
 # Configure Man Page Installation

--- a/README.md
+++ b/README.md
@@ -1,16 +1,38 @@
 # git-chat
+
 ![CI/PR](https://github.com/brandon1024/gitchat/workflows/CI/PR/badge.svg)
 
-`git-chat` is a command-line messaging application built on the fundamentals of `Git` and `GnuPG`.
+`git-chat` is a command-line messaging application built on the fundamentals of
+`Git` and `GnuPG`.
 
-git-chat allows multiple parties to communicate securely by _committing_ messages to branches on an upstream Git repository. Textual messages are gpg-encrypted (ascii-armored) and embedded as commit messages and committed on a branch (referred as a channel). Individuals may join a channel by committing their gpg public keys, allowing others to include them as a recipient in new messages.
+git-chat allows multiple parties to communicate securely by _committing_
+messages to branches on an upstream Git repository. Textual messages are
+gpg-encrypted (ascii-armored) and embedded as commit messages and committed on a
+branch (referred as a channel). Individuals may join a channel by committing
+their gpg public keys, allowing others to include them as a recipient in new
+messages.
 
-This project is a meme. If you're using git-chat for messaging with your savvy friends, you're an awesome person. Please do keep in mind that git-chat should not be used for secure and tamper proof communication because it suffers from tampering (lost messages, erased history, etc.). Use at your own risk.
+This project is a meme. If you're using git-chat for messaging with your savvy
+friends, you're an awesome person. Please do keep in mind that git-chat should
+not be used for secure and tamper proof communication because it suffers from
+tampering (lost messages, erased history, etc.). Use at your own risk.
 
-![](screenshare.gif)
+![](./github/screenshare.gif)
 
 ## Building git-chat
-By default, git-chat is installed into your `${HOME}`. To install, from the project root run:
+
+git-chat builds with CMake, which you must have installed. Aside from a handful
+of widely available build tools, you will need a suitable installation of
+[GPGme](https://gnupg.org/software/gpgme/index.html). Git and Pinentry are
+needed at runtime.
+
+```shell
+$ apt install build-essential git cmake libgpgme-dev pinentry-curses
+```
+
+By default, git-chat is installed into your `${HOME}`. To install, from the
+project root run:
+
 ```
 $ cmake -B build -S .
 $ make -C build all install
@@ -18,6 +40,7 @@ $ ~/bin/git-chat --version
 ```
 
 For a global install, from the project root run:
+
 ```
 $ cmake -B build -S . -DCMAKE_INSTALL_PREFIX=/usr/local
 $ make -C build all install
@@ -25,7 +48,9 @@ $ git-chat --version
 ```
 
 ### Running Tests
-The steps below are the very basics--just enough to get you started. For more details, see `test/README.md`.
+
+The steps below are the very basics--just enough to get you started. For more
+details, see `test/README.md`.
 
 ```
 $ # unit tests
@@ -38,10 +63,17 @@ $ make -C build/ integration
 ```
 
 ## Using git-chat
-`Git` has a neat way of allowing third parties to create extensions to Git that can be run as if they were builtins. If an executable on the PATH is prefixed with `git-`, git will execute it if the subcommand matches what follows after the prefix. Since git-chat is installed as an executable `git-chat`, you can invoke git-chat by simply running `git chat [args]`.
+
+`Git` has a neat way of allowing third parties to create extensions to Git that
+can be run as if they were builtins. If an executable on the PATH is prefixed
+with `git-`, git will execute it if the subcommand matches what follows after
+the prefix. Since git-chat is installed as an executable `git-chat`, you can
+invoke git-chat by simply running `git chat [args]`.
 
 ### git chat init
-Initialize a new messaging space. This will call 'git init' to initialize the repository, and then setup the repository to be used for messaging.
+
+Initialize a new messaging space. This will call 'git init' to initialize the
+repository, and then setup the repository to be used for messaging.
 
 ```
 usage: git chat init [(-n | --name) <name>] [(-d | --description) <desc>]
@@ -56,6 +88,7 @@ usage: git chat init [(-n | --name) <name>] [(-d | --description) <desc>]
 ```
 
 ### git chat import-key
+
 Import gpg keys into the git-chat keyring and commit them to a channel.
 
 ```
@@ -70,6 +103,7 @@ usage: git chat import-key [--gpg-home <path>] [--] <key fpr>...
 ```
 
 ### git chat channel
+
 Create a new channel by branching off the current point in the conversation.
 
 ```
@@ -88,7 +122,10 @@ usage: git chat channel create [(-n | --name) <alias>] [(-d | --description) <de
 ```
 
 ### git chat message
-Create a new message in the current channel. The message is encrypted with GPG. The message is not yet published, and needs to be pushed to the remote repository using `git chat publish`.
+
+Create a new message in the current channel. The message is encrypted with GPG.
+The message is not yet published, and needs to be pushed to the remote
+repository using `git chat publish`.
 
 ```
 usage: git chat message [(--recipient <alias>)...] [(--reply | --compose <n>)]
@@ -109,9 +146,12 @@ usage: git chat message [(--recipient <alias>)...] [(--reply | --compose <n>)]
 ```
 
 ### git chat publish
-This feature is not implemented. Messages can be published with `git push`. Consider creating a `git chat publish` alias.
+
+This feature is not implemented. Messages can be published with `git push`.
+Consider creating a `git chat publish` alias.
 
 ### git chat read
+
 Read messages in the current channel.
 
 ```
@@ -122,9 +162,12 @@ usage: git chat read  [(-n | --max-count) <n>] [--no-color] [<commit hash>]
 ```
 
 ### git chat get
-This feature is not implemented. Messages can be fetched with `git pull --ff-only`. Consider creating a `git chat get` alias.
+
+This feature is not implemented. Messages can be fetched with `git pull
+--ff-only`. Consider creating a `git chat get` alias.
 
 ### git chat config
+
 ```
 usage: git chat config [--get] <key>
    or: git chat config --get-or-default <key>
@@ -145,7 +188,11 @@ usage: git chat config [--get] <key>
 ```
 
 ## Extending git-chat
-git-chat follows a similar extension model to Git, where executables located on the PATH that are prefixed with `git-chat-` will be invoked when `git chat <extension name>` is run at the command line. This allows you to build custom plugins to git-chat.
+
+git-chat follows a similar extension model to Git, where executables located on
+the PATH that are prefixed with `git-chat-` will be invoked when `git chat
+<extension name>` is run at the command line. This allows you to build custom
+plugins to git-chat.
 
 ## Contributors
 

--- a/cmake/Modules/FindGPGME.cmake
+++ b/cmake/Modules/FindGPGME.cmake
@@ -1,193 +1,40 @@
-# This script was taken and adapted from rpm-software-management/librepo:
-# https://github.com/rpm-software-management/librepo/blob/master/cmake/Modules/FindGpgme.cmake
+# FindGPGME - Lookup native libgpgme installation.
 #
-# Try to find the gpgme library:
-#	There's also three variants: gpgme{,-pthread,-pth}. The variant used determines the multithreaded use possible:
-#		- gpgme:         no multithreading support available
-#		- gpgme-pthread: multithreading available using POSIX threads
-#		- gpgme-pth:     multithreading available using GNU PTH (cooperative multithreading)
-#	- GPGME_{VANILLA,PTH,PTHREAD}_{FOUND,LIBRARIES} will be set for each of the above
-#	- GPGME_INCLUDES is the same for all of the above
-#	- GPGME_FOUND is set if any of the above was found
+# This module provides the following imported library targets:
 #
-#	GPGME_LIBRARY_DIR - the directory where the libraries are located
+# - GPGME::libgpgme
+#
+#   Target encapsulating the libgpgme usage requirements, if found.
 
-SET(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS_gpgme_saved ${CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS})
-SET(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS true)
+include(FindPackageHandleStandardArgs)
 
-MACRO(macro_bool_to_bool FOUND_VAR)
-	FOREACH (_current_VAR ${ARGN})
-		IF (${FOUND_VAR})
-			SET(${_current_VAR} TRUE)
-		ELSE ()
-			SET(${_current_VAR} FALSE)
-		ENDIF ()
-	ENDFOREACH ()
-ENDMACRO()
+find_package(PkgConfig QUIET)
 
-SET(_seem_to_have_cached_gpgme false)
-IF (GPGME_INCLUDES)
-	IF (GPGME_VANILLA_LIBRARIES OR GPGME_PTHREAD_LIBRARIES OR GPGME_PTH_LIBRARIES)
-		SET(_seem_to_have_cached_gpgme true)
-	ENDIF ()
-ENDIF ()
+if(PKG_CONFIG_FOUND)
+	pkg_check_modules(PC_GPGME QUIET gpgme)
+endif()
 
-IF (_seem_to_have_cached_gpgme)
-	macro_bool_to_bool(GPGME_VANILLA_LIBRARIES GPGME_VANILLA_FOUND)
-	macro_bool_to_bool(GPGME_PTHREAD_LIBRARIES GPGME_PTHREAD_FOUND)
-	macro_bool_to_bool(GPGME_PTH_LIBRARIES GPGME_PTH_FOUND)
+find_path(GPGME_INCLUDE_DIR NAMES gpgme.h HINTS ${PC_GPGME_INCLUDE_DIRS})
+find_library(GPGME_LIBRARY NAMES libgpgme.so HINTS ${PC_GPGME_LIBRARY_DIRS})
 
-	IF (GPGME_VANILLA_FOUND OR GPGME_PTHREAD_FOUND OR GPGME_PTH_FOUND)
-		SET(GPGME_FOUND true)
-	ELSE ()
-		SET(GPGME_FOUND false)
-	ENDIF ()
-ELSE ()
-	SET(GPGME_FOUND false)
-	SET(GPGME_VANILLA_FOUND false)
-	SET(GPGME_PTHREAD_FOUND false)
-	SET(GPGME_PTH_FOUND false)
+set(GPGME_VERSION ${PC_GPGME_VERSION})
 
-	FIND_PROGRAM(_GPGMECONFIG_EXECUTABLE NAMES gpgme-config)
-	IF (_GPGMECONFIG_EXECUTABLE)
-		MESSAGE(STATUS "Found gpgme-config at ${_GPGMECONFIG_EXECUTABLE}")
-		EXEC_PROGRAM(${_GPGMECONFIG_EXECUTABLE} ARGS --version OUTPUT_VARIABLE GPGME_VERSION)
+find_package_handle_standard_args(
+	GPGME
+	REQUIRED_VARS
+		GPGME_LIBRARY
+		GPGME_INCLUDE_DIR
+	VERSION_VAR
+		GPGME_VERSION
+)
 
-		MESSAGE(STATUS "Found gpgme v${GPGME_VERSION}, checking for flavours...")
-		EXEC_PROGRAM(${_GPGMECONFIG_EXECUTABLE} ARGS --libs OUTPUT_VARIABLE _gpgme_config_vanilla_libs RETURN_VALUE _ret)
-		IF (_ret)
-			SET(_gpgme_config_vanilla_libs)
-		ENDIF ()
+if(GPGME_FOUND AND NOT TARGET GPGME::libgpgme)
+	add_library(GPGME::libgpgme UNKNOWN IMPORTED)
+	set_target_properties(GPGME::libgpgme PROPERTIES
+		IMPORTED_LOCATION "${GPGME_LIBRARY}"
+		INTERFACE_COMPILE_OPTIONS "${PC_GPGME_CFLAGS_OTHER}"
+		INTERFACE_INCLUDE_DIRECTORIES "${GPGME_INCLUDE_DIR}"
+	)
+endif()
 
-		EXEC_PROGRAM(${_GPGMECONFIG_EXECUTABLE} ARGS --thread=pthread --libs OUTPUT_VARIABLE _gpgme_config_pthread_libs RETURN_VALUE _ret)
-		IF (_ret)
-			SET(_gpgme_config_pthread_libs)
-		ENDIF ()
-
-		EXEC_PROGRAM(${_GPGMECONFIG_EXECUTABLE} ARGS --thread=pth --libs OUTPUT_VARIABLE _gpgme_config_pth_libs RETURN_VALUE _ret)
-		IF (_ret)
-			SET(_gpgme_config_pth_libs)
-		ENDIF ()
-
-		# append -lgpg-error to the list of libraries, if necessary
-		FOREACH (_flavour vanilla pthread pth)
-			IF (_gpgme_config_${_flavour}_libs AND NOT _gpgme_config_${_flavour}_libs MATCHES "lgpg-error")
-				SET(_gpgme_config_${_flavour}_libs "${_gpgme_config_${_flavour}_libs} -lgpg-error")
-			ENDIF ()
-		ENDFOREACH ()
-
-		IF (_gpgme_config_vanilla_libs OR _gpgme_config_pthread_libs OR _gpgme_config_pth_libs)
-			EXEC_PROGRAM(${_GPGMECONFIG_EXECUTABLE} ARGS --cflags OUTPUT_VARIABLE _GPGME_CFLAGS)
-
-			IF (_GPGME_CFLAGS)
-				STRING(REGEX REPLACE "(\r?\n)+$" " " _GPGME_CFLAGS "${_GPGME_CFLAGS}")
-				STRING(REGEX REPLACE " *-I" ";" GPGME_INCLUDES "${_GPGME_CFLAGS}")
-			ENDIF ()
-
-			FOREACH (_flavour vanilla pthread pth)
-				IF (_gpgme_config_${_flavour}_libs)
-					SET(_gpgme_library_dirs)
-					SET(_gpgme_library_names)
-					STRING(TOUPPER "${_flavour}" _FLAVOUR)
-
-					STRING(REGEX REPLACE " +" ";" _gpgme_config_${_flavour}_libs "${_gpgme_config_${_flavour}_libs}")
-					FOREACH (_flag ${_gpgme_config_${_flavour}_libs})
-						IF ("${_flag}" MATCHES "^-L")
-							STRING(REGEX REPLACE "^-L" "" _dir "${_flag}")
-							file(TO_CMAKE_PATH "${_dir}" _dir)
-							SET(_gpgme_library_dirs ${_gpgme_library_dirs} "${_dir}")
-						ELSEIF ("${_flag}" MATCHES "^-l")
-							STRING(REGEX REPLACE "^-l" "" _name "${_flag}")
-							SET(_gpgme_library_names ${_gpgme_library_names} "${_name}")
-						ENDIF ()
-					ENDFOREACH ()
-
-					SET(GPGME_${_FLAVOUR}_FOUND true)
-					FOREACH (_name ${_gpgme_library_names})
-						SET(_gpgme_${_name}_lib)
-
-						# if -L options were given, look only there
-						IF (_gpgme_library_dirs)
-							FIND_LIBRARY(_gpgme_${_name}_lib NAMES ${_name} PATHS ${_gpgme_library_dirs} NO_DEFAULT_PATH)
-						ENDIF ()
-
-						# if not found there, look in system directories
-						IF (NOT _gpgme_${_name}_lib)
-							FIND_LIBRARY(_gpgme_${_name}_lib NAMES ${_name})
-						ENDIF ()
-
-						# if still not found, then the whole flavour isn't found
-						IF (NOT _gpgme_${_name}_lib)
-							IF (GPGME_${_FLAVOUR}_FOUND)
-								SET(GPGME_${_FLAVOUR}_FOUND false)
-								SET(_not_found_reason "dependent library ${_name} wasn't found")
-							ENDIF ()
-						ENDIF ()
-
-						SET(GPGME_${_FLAVOUR}_LIBRARIES ${GPGME_${_FLAVOUR}_LIBRARIES} "${_gpgme_${_name}_lib}")
-					ENDFOREACH ()
-
-					IF (GPGME_${_FLAVOUR}_FOUND)
-						MESSAGE(STATUS " Found flavour '${_flavour}', checking whether it's usable...yes")
-					ELSE ()
-						MESSAGE(STATUS " Found flavour '${_flavour}', checking whether it's usable...no")
-						MESSAGE(STATUS "  (${_not_found_reason})")
-					ENDIF ()
-				ENDIF ()
-			ENDFOREACH (_flavour)
-
-			IF (GPGME_VANILLA_FOUND OR GPGME_PTHREAD_FOUND OR GPGME_PTH_FOUND)
-				SET(GPGME_FOUND true)
-			ELSE ()
-				SET(GPGME_FOUND false)
-			ENDIF ()
-		ENDIF ()
-	ELSE ()
-		MESSAGE(STATUS "Unable to find gpgme-config")
-	ENDIF ()
-ENDIF ()
-
-SET(_gpgme_flavours "")
-IF (GPGME_VANILLA_FOUND)
-	SET(_gpgme_flavours "${_gpgme_flavours} vanilla")
-ENDIF ()
-
-IF (GPGME_GLIB_FOUND)
-	SET(_gpgme_flavours "${_gpgme_flavours} Glib")
-ENDIF ()
-
-IF (GPGME_QT_FOUND)
-	SET(_gpgme_flavours "${_gpgme_flavours} Qt")
-ENDIF ()
-
-IF (GPGME_PTHREAD_FOUND)
-	SET(_gpgme_flavours "${_gpgme_flavours} pthread")
-ENDIF ()
-
-IF (GPGME_PTH_FOUND)
-	SET(_gpgme_flavours "${_gpgme_flavours} pth")
-ENDIF ()
-
-# determine the library in one of the found flavours can be reused
-FOREACH (_currentFlavour vanilla glib qt pth pthread)
-	IF (NOT GPGME_LIBRARY_DIR)
-		get_filename_component(GPGME_LIBRARY_DIR "${_gpgme_${_currentFlavour}_lib}" PATH)
-	ENDIF ()
-ENDFOREACH ()
-
-IF (NOT Gpgme_FIND_QUIETLY)
-	IF (GPGME_FOUND)
-		MESSAGE(STATUS "Usable gpgme flavours found: ${_gpgme_flavours}")
-	ELSE ()
-		MESSAGE(STATUS "No usable gpgme flavours found.")
-	ENDIF ()
-
-	macro_bool_to_bool(Gpgme_FIND_REQUIRED _req)
-	SET(_gpgme_homepage "http://www.gnupg.org/related_software/gpgme")
-ELSE ()
-	IF (Gpgme_FIND_REQUIRED AND NOT GPGME_FOUND)
-		MESSAGE(FATAL_ERROR "Did not find GPGME")
-	ENDIF ()
-ENDIF ()
-
-SET(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS_gpgme_saved)
+mark_as_advanced(GPGME_INCLUDE_DIR GPGME_LIBRARY)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -22,6 +22,6 @@ foreach(SECTION 1 2 3 4 5 6 7 8)
 		get_filename_component(FILENAME ${FILE} NAME)
 		configure_file(${FILE} ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME})
 
-		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} DESTINATION share/man/man${SECTION})
+		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} DESTINATION ${CMAKE_INSTALL_MANDIR}/man${SECTION})
 	endforeach()
 endforeach()

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,13 @@
 # Testing git-chat
-Like any good piece of software, git-chat has a suite of unit and integration tests for testing various components. The unit tests are written in C and the integration tests are written in Bash. There are many ways to run git-chat tests, the easiest of which is by running the `test` and `integration` make targets.
+
+Like any good piece of software, git-chat has a suite of unit and integration
+tests for testing various components. The unit tests are written in C and the
+integration tests are written in Bash. There are many ways to run git-chat
+tests, the easiest of which is by running the `test` and `integration` make
+targets.
 
 ## Contents
+
 1. [Running Tests](#running-tests)
 	1. [Unit](#unit)
 		1. [Running Unit Tests with Valgrind Memcheck](#running-unit-tests-with-valgrind-memcheck)
@@ -18,15 +24,21 @@ Like any good piece of software, git-chat has a suite of unit and integration te
 		2. [Helper Functions](#helper-functions)
 
 ## Running Tests
+
 ### Unit
-Running unit tests is quite straightforward. First, you'll need to build git-chat. Then you can run the `test` target:
+
+Running unit tests is quite straightforward. First, you'll need to build
+git-chat. Then you can run the `test` target:
+
 ```
 $ cmake -B build/ -S .
 $ make -C build/ all test
 ```
 
 #### Running Unit Tests with Valgrind Memcheck
+
 Running unit tests under Valgrind memcheck is easy too!
+
 ```
 $ cmake -B build/ -S .
 $ make -C build/ all
@@ -34,13 +46,22 @@ $ make -C build/ test ARGS='-T memcheck -V'
 ```
 
 #### Configuring Unit Test Execution
-The unit test runner accepts the `GIT_CHAT_TEST_IMMEDIATE` environment variable, which is used to configure how the unit tests behave when a test fails. When set, the test suite will stop immediately when a failure is encountered. Otherwise, all tests are executed.
+
+The unit test runner accepts the `GIT_CHAT_TEST_IMMEDIATE` environment variable,
+which is used to configure how the unit tests behave when a test fails. When
+set, the test suite will stop immediately when a failure is encountered.
+Otherwise, all tests are executed.
 
 ### Integration
-The steps for running integration tests are similar to running unit tests, except that you need to install git-chat first.
+
+The steps for running integration tests are similar to running unit tests,
+except that you need to install git-chat first.
 
 #### Using the CMake Build Target
-The integration tests are configured as a CMake build target, and can executed as follows:
+
+The integration tests are configured as a CMake build target, and can executed
+as follows:
+
 ```
 $ cmake -B build/ -S .
 $ make -C build/ all install
@@ -50,7 +71,10 @@ $ make -C build/ integration
 This is the easiest way to run the tests.
 
 #### Using the Integration Runner
-The integration tests can also be executed using the `integration-runner.sh`, located in `test/`. This is a more advanced way of running tests.
+
+The integration tests can also be executed using the `integration-runner.sh`,
+located in `test/`. This is a more advanced way of running tests.
+
 ```
 $ cmake -B build/ -S .
 $ make -C build/ all install
@@ -61,15 +85,21 @@ $ # or for global installation
 $ ./test/integration-runner.sh --from-dir build/test
 ```
 
-See `integration-runner.sh --help` for more information. 
+See `integration-runner.sh --help` for more information.
 
 ## Writing Tests
+
 ### Unit Tests
-The unit tests use a lightweight and simple test framework with an unobtrusive syntax and simple suite runner. There are a few steps that need to be taken when writing new unit tests, which are outlined below.
+
+The unit tests use a lightweight and simple test framework with an unobtrusive
+syntax and simple suite runner. There are a few steps that need to be taken when
+writing new unit tests, which are outlined below.
 
 #### Adding a New Unit Test Suite
+
 1. First create the test suite under `test/unit/` and add tests:
-```
+
+```c
 #include "test-lib.h"
 
 TEST_DEFINE(test_name)
@@ -87,7 +117,8 @@ TEST_DEFINE(test_name)
 ```
 
 2. To allow this test to get picked up by the test runner, add an entrypoint and test name:
-```
+
+```c
 const char *suite_name = SUITE_NAME;
 int test_suite(struct test_runner_instance *instance)
 {
@@ -102,12 +133,15 @@ int test_suite(struct test_runner_instance *instance)
 ```
 
 3. Lastly, register this test suite to get run by adding the test to `test/CMakeLists.txt`:
-```
+
+```c
 add_unit_test(${TEST_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/unit/${TEST_SOURCE_FILE})
 ```
 
 #### Assertion Macros
+
 Default Assertion Macros:
+
 - assert_string_eq(expected, actual)
 - assert_string_neq(expected, actual)
 - assert_eq(expected, actual)
@@ -120,6 +154,7 @@ Default Assertion Macros:
 - assert_nonzero(actual)
 
 Custom Assertion Message Macros:
+
 - assert_string_eq_msg(expected, actual, fmt, ...)
 - assert_string_neq_msg(expected, actual, fmt, ...)
 - assert_eq_msg(expected, actual, fmt, ...)
@@ -132,12 +167,16 @@ Custom Assertion Message Macros:
 - assert_nonzero_msg(actual, fmt, ...)
 
 ### Integration Tests
-New integration tests should be created in the `test/integration` directory. The new tests must be executable.
 
-All integration tests must first source the test library file, which sets up assertion functions and configures the test environment.
+New integration tests should be created in the `test/integration` directory. The
+new tests must be executable.
+
+All integration tests must first source the test library file, which sets up
+assertion functions and configures the test environment.
 
 Here is a simple example:
-```
+
+```shell
 #!/usr/bin/env bash
 
 # All integration tests must source the test library
@@ -156,10 +195,15 @@ assert_success '<test description>' '
 
 Tests may use any standard bash commands or builtins, such as `grep` or `sed`.
 
-Tests are executed within a _trash_ directory, which is recreated after every integration suite. So, it is perfectly fine to create files and git repositories, granted that care is taken to avoid changing the current directory.
+Tests are executed within a _trash_ directory, which is recreated after every
+integration suite. So, it is perfectly fine to create files and git
+repositories, granted that care is taken to avoid changing the current
+directory.
 
 #### Assertion Functions
+
 1. `assert_success`
+
 ```
 assert_success (description, [test_setup], test)
 Evaluate a command or script and assert that it can execute and return with a zero exit status.
@@ -177,7 +221,9 @@ assert_success '<test description>' '
 ```
 
 #### Helper Functions
+
 1. reset_trash_dir
+
 ```
 reset_trash_dir ()
 Remove all files and directories in the trash dir.
@@ -191,6 +237,7 @@ assert success 'test reset_trash_dir' '
 ```
 
 2. setup_test_gpg
+
 ```
 setup_test_gpg ([private key path])
 Configure environment to use GPG. For commands that use GPG, this is necessary

--- a/test/integration-runner.sh
+++ b/test/integration-runner.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-function show_help () {
+show_help () {
 	cat <<EOS
 This script is the integration test runner for all integration tests.
 
@@ -156,6 +156,8 @@ if [[ ! -d "${TEST_RUNNER_PATH}/integration" ]]; then
 	exit 1
 fi
 
+export PATH="${TEST_RUNNER_PATH}/integration/bin:${PATH}"
+
 if [[ -n "${TEST_VALGRIND+x}" ]]; then
 	# When running integration tests under valgrind memcheck, we wrap the git-chat
 	# executable in valgrind.sh, which accepts the same arguments as git-chat.
@@ -176,8 +178,6 @@ if [[ -n "${TEST_VALGRIND+x}" ]]; then
 	fi
 
 	ln -s "${TEST_RUNNER_PATH}/integration/bin/valgrind.sh" "${TEST_RUNNER_PATH}/integration/bin/git-chat"
-
-	export PATH="${TEST_RUNNER_PATH}/integration/bin:${PATH}"
 elif [[ -n "${TEST_GIT_CHAT_INSTALLED+x}" ]]; then
 	export PATH="${TEST_GIT_CHAT_INSTALLED}:${PATH}"
 fi
@@ -226,6 +226,8 @@ export GIT_CEILING_DIRECTORIES="$(dirname "$TEST_TRASH_DIR")"
 
 # Trick git into using an alternate gitconfig for tests
 export GIT_CONFIG=${TEST_RESOURCES_DIR}/.gitconfig
+export GIT_CONFIG_GLOBAL=${GIT_CONFIG}
+export GIT_CONFIG_SYSTEM=${GIT_CONFIG}
 export GIT_CONFIG_NOSYSTEM=1
 
 export GIT_AUTHOR_NAME="Test User"

--- a/test/integration/t006-git-chat-message.sh
+++ b/test/integration/t006-git-chat-message.sh
@@ -106,6 +106,6 @@ assert_success 'existence of a .trusted-keys file should filter recipients' '
 	git show -s --format="%B" HEAD >commit_msg &&
 	echo password | gpg2 --pinentry-mode=loopback --passphrase-fd 0 --batch --decrypt commit_msg >out &&
 	grep "hello world" out &&
-	gpg2 --list-only --list-packets <commit_msg 2>message_details &&
+	gpg2 --list-only --list-packets <commit_msg >message_details 2>&1 &&
 	grep "C5E184648F6CEA47" message_details
 '

--- a/test/integration/test-lib.sh
+++ b/test/integration/test-lib.sh
@@ -28,11 +28,11 @@ fi
 
 cd "${TEST_TRASH_DIR}" || exit 1
 
-function fail_test () {
+fail_test () {
 	printf "  ${COLOR_RED}not ok $ASSERT_TEST_NUMBER - ${1}${COLOR_RESET}\n" 1>&2
 }
 
-function pass_test () {
+pass_test () {
 	printf "  ${COLOR_GREEN}ok $ASSERT_TEST_NUMBER - ${1}${COLOR_RESET}\n" 1>&2
 }
 
@@ -40,7 +40,7 @@ function pass_test () {
 # zero exit status.
 # usage: assert_success <message> [<test setup>] <script>
 #
-function assert_success () {
+assert_success () {
 	if [[ ${#} -eq 2 ]]; then
 		if [[ -n "${TEST_DEBUG+x}" || -n "${TEST_VERBOSE+x}" ]]; then
 			(eval "$2")
@@ -76,12 +76,12 @@ function assert_success () {
 	exit ${ASSERT_FAILED}
 }
 
-function reset_trash_dir () {
+reset_trash_dir () {
 	rm -rf -- ..?* .[!.]* *
 	return 0
 }
 
-function setup_test_gpg () {
+setup_test_gpg () {
 	rm -rf "${TEST_TRASH_DIR}/.gpg_tmp"
 	mkdir -m 700 "${TEST_TRASH_DIR}/.gpg_tmp"
 	export GNUPGHOME="${TEST_TRASH_DIR}/.gpg_tmp"


### PR DESCRIPTION
It's been a number of years since the last updates to git-chat, so this revision modernizes the build infrastructure. The build has been updated to use a more modern version of CMake, a simpler Find module for libgpgme, and some small fixes. These changes allow git-chat to build on Debian bookworm/bullseye, Ubuntu 24.04/22.04.